### PR TITLE
Bump minimist to 1.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "**/underscore": "1.12.1",
     "**/xmlhttprequest-ssl": "1.6.2",
     "**/lodash": "^4.17.19",
-    "**/minimist": "1.2.5",
+    "**/minimist": "1.2.6",
     "**/yargs-parser": "13.1.2",
     "**/cheerio": "0.12.3",
     "**/cheerio-select": "0.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2846,10 +2846,10 @@ minimatch@~3.0.2, minimatch@~3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@1.2.5, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.6, minimist@~0.0.1:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+minimist@1.2.6, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.6, minimist@~0.0.1:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 mkdirp@^0.5.4, mkdirp@^0.5.5:
   version "0.5.6"


### PR DESCRIPTION
Bump minimist to 1.2.6 to address security update
More details here: https://github.com/sequentech/voting-booth/security/dependabot/12