### PR TITLE
Fix booth header when logo_url is set

### DIFF
--- a/avBooth/booth-header-directive/booth-header-directive.html
+++ b/avBooth/booth-header-directive/booth-header-directive.html
@@ -33,33 +33,11 @@
         </div>
       </div>
 
-      <div class="col-xs-6 col-sm-4 text-right" ng-if="election.logo_url">
-        <span
-          class="glyphicon glyphicon-question-sign"
-          role="link"
-          tabindex="0"
-          ng-if="documentation.show_help"
-          ng-keyup="launchHelp()"
-          ng-click="launchHelp()">
-        </span>
-        <span
-          ng-if="documentation.show_help"
-          role="link"
-          tabindex="0"
-          ng-keyup="launchHelp()"
-          ng-click="launchHelp()" 
-          ng-i18next="avBooth.helpTitle"
-        >
-        </span>
-        <span 
-          class="dropdown left-padding"
-          role="menuitem"
-          av-change-lang
-        >
-        </span>
-      </div>
-
-      <div class="col-xs-6 text-right" ng-if="!election.logo_url">
+      <div
+        class="col-xs-6 text-right"
+        ng-class="{'col-sm-4': !!election.logo_url}"
+        ng-if="election.logo_url"
+      >
         <span
           class="glyphicon glyphicon-question-sign"
           role="link"


### PR DESCRIPTION
When the election is configured with a logo, the booth header
was not showing neither the version of software nor the log out
button. This commit fixes that.