### PR TITLE
Fix invalid & blank vote in review screen

### DIFF
--- a/avBooth/review-ballot-directive/review-ballot-directive.html
+++ b/avBooth/review-ballot-directive/review-ballot-directive.html
@@ -73,7 +73,7 @@
     </li>
     <li
       class="empty-answer"
-      ng-if="(question.answers | avbSelectedOptions).length == 0"
+      ng-if="(question.answers | avbSelectedOptions).length == 0 && !markedAsInvalid(question)"
       ng-i18next="avBooth.emptyAnswer">
     </li>
   </ul>


### PR DESCRIPTION
If a vote has been marked as invalid explicitly, it cannot be blank
because it has already one mark. So we don't show the blank vote
mark.