### PR TITLE
Removing old smart-link iframe authentication method

### DIFF
--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -218,7 +218,7 @@ angular.module('avBooth')
       autoredirectToLoginAfterTimeout();
 
       function checkCookies(electionId) {
-        if (scope.isDemo || InsideIframeService()) {
+        if (scope.isDemo) {
           return;
         }
 
@@ -610,7 +610,7 @@ angular.module('avBooth')
 
       // Try to read and process voting credentials
       function readVoteCredentials() {
-        if (scope.isDemo || InsideIframeService()) {
+        if (scope.isDemo) {
           return;
         }
         var credentialsStr = $window.sessionStorage.getItem("vote_permission_tokens");
@@ -872,38 +872,6 @@ angular.module('avBooth')
         }
       }
 
-      // Function that receives and processes authorization token when this
-      // this token is sent by a parent window when we are inside an iframe
-      function avPostAuthorization(event, errorHandler) {
-        var action = "avPostAuthorization:";
-        if (event.data.substr(0, action.length) !== action) {
-          return;
-        }
-
-        var khmacStr = event.data.substr(action.length, event.data.length);
-        var khmac = HmacService.checkKhmac(khmacStr);
-        if (!khmac) {
-          scope.authorizationReceiverErrorHandler();
-          showError($i18next("avBooth.errorLoadingElection"));
-          return;
-        }
-        scope.authorizationHeader = khmacStr;
-        var splitMessage = khmac.message.split(":");
-
-        if (splitMessage.length < 4) {
-          scope.authorizationReceiverErrorHandler();
-          return;
-        }
-        scope.voterId = splitMessage[0];
-        scope.authorizationReceiver();
-        scope.authorizationReceiver = null;
-      }
-
-      function setAuthorizationReceiver(callback, errorCallback) {
-        scope.authorizationReceiver = callback;
-        scope.authorizationReceiverErrorHandler = errorCallback;
-      }
-
       function increaseDemoElectionIndex() {
         scope.demoElectionIndex += 1;
       }
@@ -924,7 +892,6 @@ angular.module('avBooth')
         launchHelp: launchHelp,
         backFromHelp: backFromHelp,
         goToQuestion: goToQuestion,
-        setAuthorizationReceiver: setAuthorizationReceiver,
         mapQuestion: mapQuestion,
         retrieveElectionConfig: retrieveElectionConfig,
         next: next,
@@ -967,9 +934,6 @@ angular.module('avBooth')
 
       // set the initial state
       setState(stateEnum.receivingElection, {});
-
-      // allow receival of khmac token by parent window
-      $window.addEventListener('message', avPostAuthorization, false);
 
       // retrieve election config
       retrieveElectionConfig();

--- a/avBooth/booth-header-directive/booth-header-directive.html
+++ b/avBooth/booth-header-directive/booth-header-directive.html
@@ -68,7 +68,7 @@
           target="_top"
           tabindex="0"
           class="log-out-button"
-          ng-click="logoutAndRedirect()"
+          ng-click="logoutAndRedirect(true)"
         >
           <span class="glyphicon glyphicon-off"></span>
           <span ng-i18next>avBooth.logout</span>

--- a/avBooth/booth.js
+++ b/avBooth/booth.js
@@ -38,10 +38,7 @@ angular
       $scope, 
       $stateParams, 
       $filter, 
-      ConfigService, 
-      $i18next, 
-      $cookies,
-      InsideIframeService
+      ConfigService
     ) {
       $scope.isDemo = $stateParams.isDemo || false;
       $scope.electionId = $stateParams.id;

--- a/avBooth/casting-ballot-screen-directive/casting-ballot-screen-directive.js
+++ b/avBooth/casting-ballot-screen-directive/casting-ballot-screen-directive.js
@@ -21,7 +21,12 @@
  * Shown while the ballot is being encrypted and sent.
  */
 angular.module('avBooth')
-  .directive('avbCastingBallotScreen', function($i18next, CastBallotService, $timeout, $window, InsideIframeService) {
+  .directive('avbCastingBallotScreen', function(
+    $i18next,
+    CastBallotService,
+    $timeout,
+    $window
+  ) {
 
     function link(scope, element, attrs) {
       // moves the title on top of the busy indicator
@@ -93,21 +98,7 @@ angular.module('avBooth')
         CastBallotService(castingInfo);
       }
 
-      if (InsideIframeService()) {
-        scope.setAuthorizationReceiver(castBallot, function() {
-          scope.showError($i18next("avBooth.couldntSendBallotUnauthorized",
-            {msg:"error-receiving-hmac"}));
-        });
-      $window.top.postMessage(
-        "avRequestAuthorization:" +
-        angular.toJson({
-          permission: "vote",
-          object_type: "election",
-          object_id: scope.electionId
-        }), '*');
-      } else {
-        castBallot();
-      }
+      castBallot();
     }
 
     return {


### PR DESCRIPTION
Now only the documented smart-link authentication option will be
supported. This means that the old smart-link that does not require
any integration with the iam is being removed, to be able to use
iframe integration in the new smart-link authentication method.