### PR TITLE
Fix graceful voting period for parent-child elections

### DIFF
--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -700,12 +700,21 @@ angular.module('avBooth')
           $http.get(scope.baseUrl + "election/" + scope.electionId)
             .then(
               function onSuccess(response) {
-                if (!scope.isDemo && response.data.payload.state !== "started") {
+                scope.election = angular.fromJson(response.data.payload.configuration);
+                var presentation = scope.election.presentation;
+
+                if (
+                  !scope.isDemo &&
+                  response.data.payload.state !== "started" &&
+                  (
+                    !presentation ||
+                    !presentation.extra_options ||
+                    !presentation.extra_options.allow_voting_end_graceful_period
+                  )
+                ) {
                   showError($i18next("avBooth.errorElectionIsNotOpen"));
                   return;
                 }
-
-                scope.election = angular.fromJson(response.data.payload.configuration);
 
                 // if demo booth is disabled and this is a demo booth, redirect
                 // to the login page


### PR DESCRIPTION
Graceful voting period allows voters that are already logged in the voting booth to vote even if the election voting period
has ended.

However, this feature didn't work before this bugfix with parent-children elections, because the voting booth ensured that
the election needs to be within the voting period when retrieving the election from the backend, and this retrival happens for each of the children election on demand. When that check did not checkout, the voter would get an error message stating that the election is not started.

This commit fixes the issue by allowing the election to be stopped if the graceful voting period is enabled.