### PR TITLE
Fix logo max height

### DIFF
--- a/avBooth/booth-directive/booth-directive.less
+++ b/avBooth/booth-directive/booth-directive.less
@@ -27,7 +27,7 @@
   }
 
   .logo-img {
-    max-height: 150px;
+    max-height: 27px;
     max-width: 400px;
     width: auto;
   }
@@ -72,8 +72,6 @@
   }
 
   .avb-top-navbar {
-    margin-top: -3px;
-
     .center-col {
       padding: 0 15px;
     }


### PR DESCRIPTION
The css for the logo at the top left is too large, this fixes it.

Before
<img width="1347" alt="a1" src="https://user-images.githubusercontent.com/3913223/177566192-8d94b43d-c6e9-45aa-aaa0-85e3a30fa4af.png">

After
<img width="638" alt="Screenshot 2022-07-06 at 14 52 24" src="https://user-images.githubusercontent.com/3913223/177566329-25bf0aba-b476-4cc4-9e12-4b8768396b0d.png">


