### PR TITLE
Mobile UI fixes

### DIFF
--- a/avBooth/accordion-option-directive/accordion-option-directive.less
+++ b/avBooth/accordion-option-directive/accordion-option-directive.less
@@ -27,7 +27,7 @@
   .answer-text,
   .answer-category,
   .answer-description {
-    word-break: break-all;
+    word-break: break-word;
   }
 
   .opt-data {

--- a/avBooth/audit-ballot-screen-directive/audit-ballot-screen-directive.less
+++ b/avBooth/audit-ballot-screen-directive/audit-ballot-screen-directive.less
@@ -17,7 +17,7 @@
 
 [avb-audit-ballot-screen] {
   .code {
-    word-break: break-all;
+    word-break: break-word;
     padding: 7px;
     background-color: @gray-lighter;
     border-radius: 4px;

--- a/avBooth/booth-directive/booth-directive.less
+++ b/avBooth/booth-directive/booth-directive.less
@@ -179,7 +179,6 @@
   .warning-demo {
     background-color: @btn-warning-bg;
     color: #4a4a4a;
-    margin-top: 30px;
     padding-top: 10px;
   }
 

--- a/avBooth/booth-directive/booth-directive.less
+++ b/avBooth/booth-directive/booth-directive.less
@@ -68,7 +68,8 @@
     background-color: @av-primary;
     color: @btn-primary-color;
     padding: 5px;
-    min-height: 30px;
+    min-height: unset;
+    margin-bottom: 0;
   }
 
   .avb-top-navbar {

--- a/avBooth/booth-directive/booth-directive.less
+++ b/avBooth/booth-directive/booth-directive.less
@@ -63,7 +63,7 @@
     padding-right: 15px !important;
   }
 
-  .navbar-fixed-top {
+  .booth-fixed-top {
     border: none;
     background-color: @av-primary;
     color: @btn-primary-color;

--- a/avBooth/booth-header-directive/booth-header-directive.html
+++ b/avBooth/booth-header-directive/booth-header-directive.html
@@ -6,7 +6,7 @@
 >
   <div class="container">
     <div class="row avb-top-navbar">
-      <div class="col-xs-6 col-sm-4" ng-if="election.logo_url">
+      <div class="col-xs-12 col-sm-4" ng-if="election.logo_url">
         <span>
           <img
             alt="Logo Image"
@@ -34,7 +34,7 @@
       </div>
 
       <div
-        class="col-xs-6 text-right"
+        class="col-xs-12 text-right"
         ng-class="{'col-sm-4': !!election.logo_url}"
       >
         <span

--- a/avBooth/booth-header-directive/booth-header-directive.html
+++ b/avBooth/booth-header-directive/booth-header-directive.html
@@ -35,7 +35,7 @@
 
       <div
         class="col-xs-12 text-right"
-        ng-class="{'col-sm-4': !!election.logo_url}"
+        ng-class="{'col-sm-4': !!election.logo_url, 'col-sm-6': !election.logo_url}"
       >
         <span
           class="glyphicon glyphicon-question-sign"

--- a/avBooth/booth-header-directive/booth-header-directive.html
+++ b/avBooth/booth-header-directive/booth-header-directive.html
@@ -1,6 +1,6 @@
 <!-- top navbar -->
 <nav 
-  class="navbar start-screen navbar-default navbar-fixed-top"
+  class="navbar start-screen navbar-default booth-fixed-top"
   av-affix-top=".navbar-unfixed-top"
   role="navigation"
 >

--- a/avBooth/election-chooser-screen-directive/election-chooser-screen-directive.less
+++ b/avBooth/election-chooser-screen-directive/election-chooser-screen-directive.less
@@ -10,6 +10,6 @@
 
     .election-title,
     .election-description {
-        word-break: break-all;
+        word-break: break-word;
     }
 }

--- a/avBooth/multi-question-directive/multi-question-directive.less
+++ b/avBooth/multi-question-directive/multi-question-directive.less
@@ -11,7 +11,7 @@
 
   .question-title,
   .question-description {
-    word-break: break-all;
+    word-break: break-word;
   }
 
   .filter-input {

--- a/avBooth/review-ballot-directive/review-ballot-directive.less
+++ b/avBooth/review-ballot-directive/review-ballot-directive.less
@@ -29,7 +29,7 @@
     .selected-answer,
     .question-title,
     .question-description {
-      word-break: break-all;
+      word-break: break-word;
     }
 
     ul, ol {

--- a/avBooth/review-screen-directive/review-screen-directive.less
+++ b/avBooth/review-screen-directive/review-screen-directive.less
@@ -25,7 +25,7 @@
   }
 
   .election-title {
-    word-break: break-all;
+    word-break: break-word;
   }
 
   .locator-text-click-audit {

--- a/avBooth/simultaneous-question-answer-directive/simultaneous-question-answer-directive.less
+++ b/avBooth/simultaneous-question-answer-directive/simultaneous-question-answer-directive.less
@@ -88,12 +88,12 @@
       .answer-text {
         font-size: 18px;
         font-weight: bold;
-        word-break: break-all;
+        word-break: break-word;
       }
 
       .answer-details {
         font-size: 14px;
-        word-break: break-all;
+        word-break: break-word;
       }
     }
 

--- a/avBooth/simultaneous-questions-screen-directive/simultaneous-questions-screen-directive.less
+++ b/avBooth/simultaneous-questions-screen-directive/simultaneous-questions-screen-directive.less
@@ -93,7 +93,7 @@
   .election-title,
   .question-description,
   .error-list li {
-    word-break: break-all;
+    word-break: break-word;
   }
 
   .question-answer-wrapper.col-md-12,

--- a/avBooth/start-screen-directive/start-screen-directive.less
+++ b/avBooth/start-screen-directive/start-screen-directive.less
@@ -27,6 +27,6 @@
   .election-title,
   .election-description,
   .legal-terms {
-    word-break: break-all;
+    word-break: break-word;
   }
 }

--- a/avBooth/success-screen-directive/success-screen-directive.less
+++ b/avBooth/success-screen-directive/success-screen-directive.less
@@ -25,7 +25,7 @@
 
   .success-title,
   .success-subheader {
-    word-break: break-all;
+    word-break: break-word;
   }
 
   .social-net-img {


### PR DESCRIPTION
# Changes

* Use `break-word` instead of `break-all` for word-wrap css property. This breaks on words rather than mid-word.
* For the navbar at the top, stop using `navbar-fixed-top` as it uses `fixed`/absolute positioning and that doesn't work well with the warning.
* Use full rows for the mobile version of the navbar. Not the full requested fix (which would reverse the order in mobile).