### PR TITLE
Add org details to election chooser directive

### DIFF
--- a/avBooth/election-chooser-screen-directive/election-chooser-screen-directive.js
+++ b/avBooth/election-chooser-screen-directive/election-chooser-screen-directive.js
@@ -21,10 +21,11 @@
  * Shows the steps to the user.
  */
 angular.module('avBooth')
-  .directive('avbElectionChooserScreen',  function($window, $cookies) {
+  .directive('avbElectionChooserScreen',  function($window, $cookies, ConfigService) {
 
     function link(scope, element, attrs) {
         scope.showSkippedElections = false;
+        scope.organization = ConfigService.organization;
         function findElectionCredentials(electionId, credentials) {
             return _.find(
                 credentials,


### PR DESCRIPTION
Previously the election chooser directive wasn't setting the organization in scope, as other directives do. This meant the "powered by " was set empty. This fixes it.