### PR TITLE
Support showing PDF in start-screen

### DIFF
--- a/app.less
+++ b/app.less
@@ -48,3 +48,4 @@
 @import "avBooth/start-screen-directive/start-screen-directive.less";
 @import "avBooth/circle-option-directive/circle-option-directive.less";
 @import "avBooth/success-screen-directive/success-screen-directive.less";
+@import "avBooth/show-pdf-directive/show-pdf-directive.less";

--- a/avBooth/booth-directive/booth-directive.html
+++ b/avBooth/booth-directive/booth-directive.html
@@ -36,6 +36,8 @@
   </div>
   <div avb-success-screen ng-if="state == stateEnum.successScreen">
   </div>
+  <div avb-show-pdf ng-if="state == stateEnum.showPdf">
+  </div>
 </div>
 <style 
   ng-if="allowCustomElectionThemeCss === true" 

--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -721,7 +721,7 @@ angular.module('avBooth')
               function onSuccess(response) {
                 scope.election = angular.fromJson(response.data.payload.configuration);
                 var presentation = scope.election.presentation;
-                scope.state = response.data.payload.state;
+                scope.electionState = response.data.payload.state;
 
                 // reset $window.i18nOverride
                 if (presentation && presentation.i18n_override)

--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -731,6 +731,8 @@ angular.module('avBooth')
                   );
                 }
 
+                var showPdf = "true" === window.sessionStorage.getItem("show-pdf");
+
                 if (
                   !scope.isDemo &&
                   response.data.payload.state !== "started" &&
@@ -738,7 +740,8 @@ angular.module('avBooth')
                     !presentation ||
                     !presentation.extra_options ||
                     !presentation.extra_options.allow_voting_end_graceful_period
-                  )
+                  ) &&
+                  !showPdf
                 ) {
                   showError($i18next("avBooth.errorElectionIsNotOpen"));
                   return;
@@ -834,7 +837,6 @@ angular.module('avBooth')
                   goToQuestion(0, false);
                 } else {
                   checkCookies(scope.electionId);
-                  var showPdf = "true" === window.sessionStorage.getItem("show-pdf");
                   if (showPdf) {
                     scope.setState(stateEnum.showPdf, {});
                   } else {

--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -721,6 +721,7 @@ angular.module('avBooth')
               function onSuccess(response) {
                 scope.election = angular.fromJson(response.data.payload.configuration);
                 var presentation = scope.election.presentation;
+                scope.state = response.data.payload.state;
 
                 // reset $window.i18nOverride
                 if (presentation && presentation.i18n_override)

--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -248,7 +248,8 @@ angular.module('avBooth')
         castOrCancelScreen: 'castOrCancelScreen',
         reviewScreen: 'reviewScreen',
         castingBallotScreen: 'castingBallotScreen',
-        successScreen: 'successScreen'
+        successScreen: 'successScreen',
+        showPdf: 'showPdf'
       };
 
       // override state if in debug mode and it's provided via query param
@@ -830,8 +831,13 @@ angular.module('avBooth')
                   goToQuestion(0, false);
                 } else {
                   checkCookies(scope.electionId);
-                  scope.hasSeenStartScreenInThisSession = true;
-                  scope.setState(stateEnum.startScreen, {});
+                  var showPdf = "true" === window.sessionStorage.getItem("show-pdf");
+                  if (showPdf) {
+                    scope.setState(stateEnum.showPdf, {});
+                  } else {
+                    scope.hasSeenStartScreenInThisSession = true;
+                    scope.setState(stateEnum.startScreen, {});
+                  }
                 }
               },
               // on error, like parse error or 404

--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -479,7 +479,6 @@ angular.module('avBooth')
         } else if (scope.state === stateEnum.startScreen)
         {
           goToQuestion(0, false);
-
         } else if (scope.state === stateEnum.reviewScreen)
         {
           if (!scope.stateData.auditClicked) {
@@ -573,6 +572,10 @@ angular.module('avBooth')
                    !scope.stateData.isLastQuestion)
         {
           goToQuestion(scope.stateData.questionNum + 1, false);
+
+        } else if (scope.state === stateEnum.showPdf)
+        {
+          scope.setState(stateEnum.startScreen, {});
         }
       }
 

--- a/avBooth/election-chooser-screen-directive/election-chooser-screen-directive.js
+++ b/avBooth/election-chooser-screen-directive/election-chooser-screen-directive.js
@@ -21,10 +21,11 @@
  * Shows the steps to the user.
  */
 angular.module('avBooth')
-  .directive('avbElectionChooserScreen',  function($window, $cookies) {
+  .directive('avbElectionChooserScreen',  function($window, $cookies, ConfigService) {
 
     function link(scope, element, attrs) {
         scope.showSkippedElections = false;
+        scope.organization = ConfigService.organization;
         function findElectionCredentials(electionId, credentials) {
             return _.find(
                 credentials,

--- a/avBooth/show-pdf-directive/show-pdf-directive.html
+++ b/avBooth/show-pdf-directive/show-pdf-directive.html
@@ -14,15 +14,15 @@
 </div>
 
 <div class="content avb-content start-screen">
-    <div class="container" ng-if="show_pdf">
-      <div class="row" ng-click="toggleExpand()">
+    <div class="container pdf-container" ng-if="show_pdf">
+      <div class="row pdf-expander" ng-click="toggleExpand()">
         <span
           class="glyphicon glyphicon-chevron-down"
           ng-if="expanded"
           aria-hidden="true">
         </span>
         <span
-          class="glyphicon glyphicon-chevron-up"
+          class="glyphicon glyphicon-chevron-right"
           ng-if="!expanded"
           aria-hidden="true">
         </span>

--- a/avBooth/show-pdf-directive/show-pdf-directive.html
+++ b/avBooth/show-pdf-directive/show-pdf-directive.html
@@ -18,7 +18,7 @@
 </div>
 
 <div class="content avb-content start-screen">
-    <div class="container pdf-container" ng-if="show_pdf">
+    <div class="container pdf-container" ng-class="{'flex-grow': expanded}" ng-if="show_pdf">
       <div class="row pdf-expander" ng-click="toggleExpand()">
         <span
           class="glyphicon glyphicon-chevron-down"
@@ -42,7 +42,7 @@
           </iframe>
       </div>
     </div>
-    <div class="container" ng-if="enable_vote">
+    <div class="container btn-container" ng-if="enable_vote">
       <div class="row" ng-if="!expanded">
         <button
           class="btn btn-block btn-lg btn-success-action btn-plain"

--- a/avBooth/show-pdf-directive/show-pdf-directive.html
+++ b/avBooth/show-pdf-directive/show-pdf-directive.html
@@ -1,0 +1,1 @@
+<div>Felix was here</div>

--- a/avBooth/show-pdf-directive/show-pdf-directive.html
+++ b/avBooth/show-pdf-directive/show-pdf-directive.html
@@ -14,37 +14,39 @@
 </div>
 
 <div class="content avb-content start-screen">
+    <div class="container" ng-if="show_pdf">
+      <div class="row" ng-click="toggleExpand()">
+        <span
+          class="glyphicon glyphicon-chevron-down"
+          ng-if="expanded"
+          aria-hidden="true">
+        </span>
+        <span
+          class="glyphicon glyphicon-chevron-up"
+          ng-if="!expanded"
+          aria-hidden="true">
+        </span>
+        Show PDF
+      </div>
+      <div class="row" ng-if="expanded">
+        <div class="padded col-xs-12">
+          <p ng-bind-html="pdf_title"></p>
+        </div>
+      </div>
+      <div class="row" ng-if="expanded">
+          <iframe class="pdf-frame" src="{{ pdf_url }}">
+          </iframe>
+      </div>
+    </div>
     <div class="container">
-        <div class="row" ng-if="show_pdf">
-          <div class="padded col-xs-12">
-            <h2 ng-bind-html="pdf_title"></h2>
-          </div>
-        </div>
-        <div class="row" ng-click="toggleExpand()">
-            <span
-              class="glyphicon glyphicon-chevron-down"
-              ng-if="expanded"
-              aria-hidden="true">
-            </span>
-            <span
-              class="glyphicon glyphicon-chevron-up"
-              ng-if="!expanded"
-              aria-hidden="true">
-            </span>
-            Show PDF
-        </div>
-        <div class="row" ng-if="show_pdf">
-            <iframe class="pdf-frame" src="{{ pdf_url }}">
-            </iframe>
-        </div>
-        <div class="row hidden" ng-cloak av-affix-bottom data-force-affix-width="768">
-          <button
-            class="btn btn-block btn-lg btn-success-action btn-plain"
-            ng-i18next="avBooth.startVoting"
-            ng-disabled="!enable_vote"
-            ng-click="next()">
-          </button>
-        </div>
+      <div class="row" ng-if="enable_vote">
+        <button
+          class="btn btn-block btn-lg btn-success-action btn-plain"
+          ng-i18next="avBooth.startVoting"
+          ng-click="next()">
+        </button>
+      </div>
+      <div class="row">
         <p
           class="text-center"
         >
@@ -56,5 +58,6 @@
             avBooth.logout
           </a>
         </p>
+      </div>
     </div>
 </div>

--- a/avBooth/show-pdf-directive/show-pdf-directive.html
+++ b/avBooth/show-pdf-directive/show-pdf-directive.html
@@ -21,11 +21,12 @@
     <div class="container">
         <div class="row" ng-if="show_pdf">
           <div class="padded col-xs-12">
-            <h2 ng-bind-html="pdf_url.title"></h2>
+            <h2 ng-bind-html="pdf_title"></h2>
           </div>
         </div>
         <div class="row" ng-if="show_pdf">
-            <iframe src="pdf_url.url"></iframe> 
+            <iframe class="pdf-frame" src="{{ pdf_url }}">
+            </iframe>
         </div>
         <div class="row hidden" ng-cloak av-affix-bottom data-force-affix-width="768">
           <button

--- a/avBooth/show-pdf-directive/show-pdf-directive.html
+++ b/avBooth/show-pdf-directive/show-pdf-directive.html
@@ -9,10 +9,6 @@
         class="election-title"
         ng-bind-html="parentElection && (parentElection.presentation.extra_options.public_title || parentElection.title) || !parentElection && (election.presentation.extra_options.public_title || election.title) || ''"
       ></h1>
-      <p
-        class="election-description description" 
-        ng-bind-html="((parentElection && parentElection.description) || (!parentElection && election.description) || '') | addTargetBlank"
-      ></p>
     </div>
   </div>
 </div>
@@ -23,6 +19,19 @@
           <div class="padded col-xs-12">
             <h2 ng-bind-html="pdf_title"></h2>
           </div>
+        </div>
+        <div class="row" ng-click="toggleExpand()">
+            <span
+              class="glyphicon glyphicon-chevron-down"
+              ng-if="expanded"
+              aria-hidden="true">
+            </span>
+            <span
+              class="glyphicon glyphicon-chevron-up"
+              ng-if="!expanded"
+              aria-hidden="true">
+            </span>
+            Show PDF
         </div>
         <div class="row" ng-if="show_pdf">
             <iframe class="pdf-frame" src="{{ pdf_url }}">
@@ -36,5 +45,16 @@
             ng-click="next()">
           </button>
         </div>
+        <p
+          class="text-center"
+        >
+          <a
+            tabindex="0"
+            ng-click="logoutAndRedirect(false)"
+            target="_top"
+            class="logout-btn btn btn-default" ng-i18next>
+            avBooth.logout
+          </a>
+        </p>
     </div>
 </div>

--- a/avBooth/show-pdf-directive/show-pdf-directive.html
+++ b/avBooth/show-pdf-directive/show-pdf-directive.html
@@ -26,11 +26,11 @@
           ng-if="!expanded"
           aria-hidden="true">
         </span>
-        Show PDF
+        <span ng-i18next="avBooth.showPdf.showPdfButton"></span>
       </div>
       <div class="row" ng-if="expanded">
         <div class="padded col-xs-12">
-          <p ng-bind-html="pdf_title"></p>
+          <p class="pdf-text" ng-bind-html="pdf_text"></p>
         </div>
       </div>
       <div class="frame-container" ng-if="expanded">

--- a/avBooth/show-pdf-directive/show-pdf-directive.html
+++ b/avBooth/show-pdf-directive/show-pdf-directive.html
@@ -9,6 +9,10 @@
         class="election-title"
         ng-bind-html="parentElection && (parentElection.presentation.extra_options.public_title || parentElection.title) || !parentElection && (election.presentation.extra_options.public_title || election.title) || ''"
       ></h1>
+      <p
+        class="pdf-text-description description" 
+        ng-i18next="avBooth.showPdf.pdfTextDescription"
+      ></p>
     </div>
   </div>
 </div>
@@ -26,7 +30,7 @@
           ng-if="!expanded"
           aria-hidden="true">
         </span>
-        <span ng-i18next="avBooth.showPdf.showPdfButton"></span>
+        <span ng-i18next="avBooth.showPdf.showPdfButton" class="show-pdf-button"></span>
       </div>
       <div class="row" ng-if="expanded">
         <div class="padded col-xs-12">
@@ -38,8 +42,15 @@
           </iframe>
       </div>
     </div>
-    <div class="container">
-      <div class="row" ng-if="enable_vote">
+    <div class="container" ng-if="enable_vote">
+      <div class="row" ng-if="!expanded">
+        <button
+          class="btn btn-block btn-lg btn-success-action btn-plain"
+          ng-i18next="avBooth.startVoting"
+          ng-click="next()">
+        </button>
+      </div>
+      <div class="row hidden" ng-cloak av-affix-bottom data-force-affix-width="768" ng-if="expanded">
         <button
           class="btn btn-block btn-lg btn-success-action btn-plain"
           ng-i18next="avBooth.startVoting"

--- a/avBooth/show-pdf-directive/show-pdf-directive.html
+++ b/avBooth/show-pdf-directive/show-pdf-directive.html
@@ -1,13 +1,37 @@
 <!-- top navbar -->
 <div avb-booth-header></div>
 
+<div class="wrapper-unfixed">
+  <div class="navbar-unfixed-top text-center">
+    <div class="container">
+      <div class="hidden unfixed-top-height"></div>
+      <h1
+        class="election-title"
+        ng-bind-html="parentElection && (parentElection.presentation.extra_options.public_title || parentElection.title) || !parentElection && (election.presentation.extra_options.public_title || election.title) || ''"
+      ></h1>
+      <p
+        class="election-description description" 
+        ng-bind-html="((parentElection && parentElection.description) || (!parentElection && election.description) || '') | addTargetBlank"
+      ></p>
+    </div>
+  </div>
+</div>
+
 <div class="content avb-content start-screen">
     <div class="container">
-        <div>Felix was here</div>
+        <div class="row" ng-if="show_pdf">
+          <div class="padded col-xs-12">
+            <h2 ng-bind-html="pdf_url.title"></h2>
+          </div>
+        </div>
+        <div class="row" ng-if="show_pdf">
+            <iframe src="pdf_url.url"></iframe> 
+        </div>
         <div class="row hidden" ng-cloak av-affix-bottom data-force-affix-width="768">
           <button
             class="btn btn-block btn-lg btn-success-action btn-plain"
             ng-i18next="avBooth.startVoting"
+            ng-disabled="!enable_vote"
             ng-click="next()">
           </button>
         </div>

--- a/avBooth/show-pdf-directive/show-pdf-directive.html
+++ b/avBooth/show-pdf-directive/show-pdf-directive.html
@@ -33,7 +33,7 @@
           <p ng-bind-html="pdf_title"></p>
         </div>
       </div>
-      <div class="row" ng-if="expanded">
+      <div class="frame-container" ng-if="expanded">
           <iframe class="pdf-frame" src="{{ pdf_url }}">
           </iframe>
       </div>
@@ -45,19 +45,6 @@
           ng-i18next="avBooth.startVoting"
           ng-click="next()">
         </button>
-      </div>
-      <div class="row">
-        <p
-          class="text-center"
-        >
-          <a
-            tabindex="0"
-            ng-click="logoutAndRedirect(false)"
-            target="_top"
-            class="logout-btn btn btn-default" ng-i18next>
-            avBooth.logout
-          </a>
-        </p>
       </div>
     </div>
 </div>

--- a/avBooth/show-pdf-directive/show-pdf-directive.html
+++ b/avBooth/show-pdf-directive/show-pdf-directive.html
@@ -1,1 +1,15 @@
-<div>Felix was here</div>
+<!-- top navbar -->
+<div avb-booth-header></div>
+
+<div class="content avb-content start-screen">
+    <div class="container">
+        <div>Felix was here</div>
+        <div class="row hidden" ng-cloak av-affix-bottom data-force-affix-width="768">
+          <button
+            class="btn btn-block btn-lg btn-success-action btn-plain"
+            ng-i18next="avBooth.startVoting"
+            ng-click="next()">
+          </button>
+        </div>
+    </div>
+</div>

--- a/avBooth/show-pdf-directive/show-pdf-directive.js
+++ b/avBooth/show-pdf-directive/show-pdf-directive.js
@@ -27,7 +27,7 @@ angular.module('avBooth')
       scope.show_pdf = angular.isObject(scope.election.presentation.pdf_url);
       scope.pdf_title = scope.show_pdf? scope.election.presentation.pdf_url.title : '';
       scope.pdf_url = scope.show_pdf? $sce.trustAsResourceUrl(scope.election.presentation.pdf_url.url) : '';
-      scope.enable_vote = ["started", "resumed"].includes(scope.election.state);
+      scope.enable_vote = ["started", "resumed"].includes(scope.state);
     };
 
     return {

--- a/avBooth/show-pdf-directive/show-pdf-directive.js
+++ b/avBooth/show-pdf-directive/show-pdf-directive.js
@@ -23,12 +23,15 @@
 angular.module('avBooth')
   .directive('avbShowPdf', function($window, IsService) {
 
-    var link = function(scope, element, attrs) {};
+    var link = function(scope, element, attrs) {
+      scope.show_pdf = angular.isObject(scope.election.presentation.pdf_url);
+      scope.enable_vote = ["started", "resumed"].includes(scope.election.state);
+      scope.pdf_url = scope.election.presentation.pdf_url;
+    };
 
     return {
       restrict: 'AE',
-      scope: {
-      },
+      scope: true,
       link: link,
       templateUrl: 'avBooth/show-pdf-directive/show-pdf-directive.html'
     };

--- a/avBooth/show-pdf-directive/show-pdf-directive.js
+++ b/avBooth/show-pdf-directive/show-pdf-directive.js
@@ -26,7 +26,7 @@ angular.module('avBooth')
     var link = function(scope, element, attrs) {
       scope.organization = ConfigService.organization;
       scope.show_pdf = angular.isObject(scope.election.presentation.pdf_url);
-      scope.pdf_title = scope.show_pdf? scope.election.presentation.pdf_url.title : '';
+      scope.pdf_text = scope.show_pdf? scope.election.presentation.pdf_url.title : '';
       scope.pdf_url = scope.show_pdf? $sce.trustAsResourceUrl(scope.election.presentation.pdf_url.url) : '';
       scope.enable_vote = ["started", "resumed"].includes(scope.electionState);
       scope.expanded = false;

--- a/avBooth/show-pdf-directive/show-pdf-directive.js
+++ b/avBooth/show-pdf-directive/show-pdf-directive.js
@@ -28,7 +28,6 @@ angular.module('avBooth')
       scope.pdf_title = scope.show_pdf? scope.election.presentation.pdf_url.title : '';
       scope.pdf_url = scope.show_pdf? $sce.trustAsResourceUrl(scope.election.presentation.pdf_url.url) : '';
       scope.enable_vote = ["started", "resumed"].includes(scope.election.state);
-      scope.pdf_url = scope.election.presentation.pdf_url;
     };
 
     return {

--- a/avBooth/show-pdf-directive/show-pdf-directive.js
+++ b/avBooth/show-pdf-directive/show-pdf-directive.js
@@ -1,0 +1,35 @@
+/**
+ * This file is part of voting-booth.
+ * Copyright (C) 2022  Sequent Tech Inc <legal@sequentech.io>
+
+ * voting-booth is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License.
+
+ * voting-booth  is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+
+ * You should have received a copy of the GNU Affero General Public License
+ * along with voting-booth.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+/*
+ * Selected Options directive.
+ *
+ * Lists the selected options for a question, allowing to change selection.
+ */
+angular.module('avBooth')
+  .directive('avbShowPdf', function($window, IsService) {
+
+    var link = function(scope, element, attrs) {};
+
+    return {
+      restrict: 'AE',
+      scope: {
+      },
+      link: link,
+      templateUrl: 'avBooth/show-pdf-directive/show-pdf-directive.html'
+    };
+  });

--- a/avBooth/show-pdf-directive/show-pdf-directive.js
+++ b/avBooth/show-pdf-directive/show-pdf-directive.js
@@ -27,7 +27,7 @@ angular.module('avBooth')
       scope.show_pdf = angular.isObject(scope.election.presentation.pdf_url);
       scope.pdf_title = scope.show_pdf? scope.election.presentation.pdf_url.title : '';
       scope.pdf_url = scope.show_pdf? $sce.trustAsResourceUrl(scope.election.presentation.pdf_url.url) : '';
-      scope.enable_vote = ["started", "resumed"].includes(scope.state);
+      scope.enable_vote = ["started", "resumed"].includes(scope.electionState);
     };
 
     return {

--- a/avBooth/show-pdf-directive/show-pdf-directive.js
+++ b/avBooth/show-pdf-directive/show-pdf-directive.js
@@ -21,10 +21,12 @@
  * Lists the selected options for a question, allowing to change selection.
  */
 angular.module('avBooth')
-  .directive('avbShowPdf', function($window, IsService) {
+  .directive('avbShowPdf', function($sce) {
 
     var link = function(scope, element, attrs) {
       scope.show_pdf = angular.isObject(scope.election.presentation.pdf_url);
+      scope.pdf_title = scope.show_pdf? scope.election.presentation.pdf_url.title : '';
+      scope.pdf_url = scope.show_pdf? $sce.trustAsResourceUrl(scope.election.presentation.pdf_url.url) : '';
       scope.enable_vote = ["started", "resumed"].includes(scope.election.state);
       scope.pdf_url = scope.election.presentation.pdf_url;
     };

--- a/avBooth/show-pdf-directive/show-pdf-directive.js
+++ b/avBooth/show-pdf-directive/show-pdf-directive.js
@@ -16,18 +16,23 @@
 **/
 
 /*
- * Selected Options directive.
+ * Show PDF directive.
  *
- * Lists the selected options for a question, allowing to change selection.
+ * Shows PDF for election, and enables voting if election is open.
  */
 angular.module('avBooth')
-  .directive('avbShowPdf', function($sce) {
+  .directive('avbShowPdf', function(ConfigService, $sce) {
 
     var link = function(scope, element, attrs) {
+      scope.organization = ConfigService.organization;
       scope.show_pdf = angular.isObject(scope.election.presentation.pdf_url);
       scope.pdf_title = scope.show_pdf? scope.election.presentation.pdf_url.title : '';
       scope.pdf_url = scope.show_pdf? $sce.trustAsResourceUrl(scope.election.presentation.pdf_url.url) : '';
       scope.enable_vote = ["started", "resumed"].includes(scope.electionState);
+      scope.expanded = false;
+      scope.toggleExpand = function () {
+        scope.expanded = !scope.expanded;
+      };
     };
 
     return {

--- a/avBooth/show-pdf-directive/show-pdf-directive.less
+++ b/avBooth/show-pdf-directive/show-pdf-directive.less
@@ -1,0 +1,18 @@
+/**
+ * This file is part of voting-booth.
+ * Copyright (C) 2022  Sequent Tech Inc <legal@sequentech.io>
+
+ * voting-booth is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License.
+
+ * voting-booth  is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+
+ * You should have received a copy of the GNU Affero General Public License
+ * along with voting-booth.  If not, see <http://www.gnu.org/licenses/>.
+**/
+[avb-show-pdf] {
+}

--- a/avBooth/show-pdf-directive/show-pdf-directive.less
+++ b/avBooth/show-pdf-directive/show-pdf-directive.less
@@ -34,12 +34,18 @@
     .pdf-container {
         display: flex;
         flex-direction: column;
-        flex-grow: 2;
         padding: 0;
         background-color: @av-bg;
         margin-top: 5px;
         margin-bottom: 44px;
         transition: 0.3s linear all;
+        width: 100%;
+    }
+    .btn-container {
+        width: 100;
+    }
+    .flex-grow {
+        flex-grow: 2;
     }
     .pdf-text {
         padding: 8px 0;

--- a/avBooth/show-pdf-directive/show-pdf-directive.less
+++ b/avBooth/show-pdf-directive/show-pdf-directive.less
@@ -15,11 +15,26 @@
  * along with voting-booth.  If not, see <http://www.gnu.org/licenses/>.
 **/
 [avb-show-pdf] {
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+
+    .avb-content {
+        display: flex;
+        flex-direction: column;
+        flex-grow: 2;
+    }
+
     .pdf-frame {
         width: 100%;
-        height: 90vh;
+        display: flex;
+        flex-direction: column;
+        flex-grow: 2;
     }
     .pdf-container {
+        display: flex;
+        flex-direction: column;
+        flex-grow: 2;
         padding: 0;
         background-color: @av-bg;
         margin-top: 5px;
@@ -40,6 +55,9 @@
         }
     }
     .frame-container {
+        display: flex;
+        flex-direction: column;
+        flex-grow: 2;
         padding: 8px;
     }
 }

--- a/avBooth/show-pdf-directive/show-pdf-directive.less
+++ b/avBooth/show-pdf-directive/show-pdf-directive.less
@@ -39,13 +39,18 @@
         margin-top: 5px;
         margin-bottom: 44px;
 
-        @media (max-width: 768px) {
+    }
+
+    @media (max-width: 768px) {
+        .pdf-container, .btn-container {
             width: 100%;
         }
+        .navbar-unfixed-top {
+            margin: 0;
+            padding-top: 0;
+        }
     }
-    .btn-container {
-        width: 100;
-    }
+
     .flex-grow {
         flex-grow: 2;
     }

--- a/avBooth/show-pdf-directive/show-pdf-directive.less
+++ b/avBooth/show-pdf-directive/show-pdf-directive.less
@@ -17,5 +17,6 @@
 [avb-show-pdf] {
     .pdf-frame {
         width: 100%;
+        height: 90vh;
     }
 }

--- a/avBooth/show-pdf-directive/show-pdf-directive.less
+++ b/avBooth/show-pdf-directive/show-pdf-directive.less
@@ -18,5 +18,6 @@
     .pdf-frame {
         width: 100%;
         height: 90vh;
+        margin-bottom: 44px;
     }
 }

--- a/avBooth/show-pdf-directive/show-pdf-directive.less
+++ b/avBooth/show-pdf-directive/show-pdf-directive.less
@@ -37,4 +37,7 @@
           background-color: darken(@av-bg, 6%);
         }
     }
+    .frame-container {
+        padding: 8px;
+    }
 }

--- a/avBooth/show-pdf-directive/show-pdf-directive.less
+++ b/avBooth/show-pdf-directive/show-pdf-directive.less
@@ -18,14 +18,16 @@
     .pdf-frame {
         width: 100%;
         height: 90vh;
-        margin-bottom: 44px;
     }
     .pdf-container {
         padding: 0;
         background-color: @av-bg;
         margin-top: 5px;
-        margin-bottom: 5px;
+        margin-bottom: 44px;
         transition: 0.3s linear all;
+    }
+    .pdf-text {
+        padding: 8px 0;
     }
     .pdf-expander {
         padding: 10px 15px;

--- a/avBooth/show-pdf-directive/show-pdf-directive.less
+++ b/avBooth/show-pdf-directive/show-pdf-directive.less
@@ -47,6 +47,19 @@
         .navbar-unfixed-top {
             margin: 0;
             padding-top: 0 !important;
+            padding-bottom: 0 !important;
+        }
+        .flex-grow {
+            margin-bottom: 0;
+        }
+        .pdf-text {
+            margin: 0;
+        }
+        .pdf-text-description {
+            margin-bottom: 0;
+        }
+        .wrapper-unfixed::after {
+            background: unset !important;
         }
     }
 

--- a/avBooth/show-pdf-directive/show-pdf-directive.less
+++ b/avBooth/show-pdf-directive/show-pdf-directive.less
@@ -49,9 +49,6 @@
             padding-top: 0 !important;
             padding-bottom: 0 !important;
         }
-        .flex-grow {
-            margin-bottom: 0;
-        }
         .pdf-text {
             margin: 0;
         }
@@ -61,10 +58,14 @@
         .wrapper-unfixed::after {
             background: unset !important;
         }
+        .pdf-text {
+            padding: 0;
+        }
     }
 
     .flex-grow {
         flex-grow: 2;
+        margin-bottom: 0;
     }
     .pdf-text {
         padding: 8px 0;

--- a/avBooth/show-pdf-directive/show-pdf-directive.less
+++ b/avBooth/show-pdf-directive/show-pdf-directive.less
@@ -15,4 +15,7 @@
  * along with voting-booth.  If not, see <http://www.gnu.org/licenses/>.
 **/
 [avb-show-pdf] {
+    .pdf-frame {
+        width: 100%;
+    }
 }

--- a/avBooth/show-pdf-directive/show-pdf-directive.less
+++ b/avBooth/show-pdf-directive/show-pdf-directive.less
@@ -38,8 +38,10 @@
         background-color: @av-bg;
         margin-top: 5px;
         margin-bottom: 44px;
-        transition: 0.3s linear all;
-        width: 100%;
+
+        @media (max-width: 768px) {
+            width: 100%;
+        }
     }
     .btn-container {
         width: 100;

--- a/avBooth/show-pdf-directive/show-pdf-directive.less
+++ b/avBooth/show-pdf-directive/show-pdf-directive.less
@@ -20,4 +20,21 @@
         height: 90vh;
         margin-bottom: 44px;
     }
+    .pdf-container {
+        padding: 0;
+        background-color: @av-bg;
+        margin-top: 5px;
+        margin-bottom: 5px;
+        transition: 0.3s linear all;
+    }
+    .pdf-expander {
+        padding: 10px 15px;
+        margin: 0;
+        font-size: 18px;
+        cursor: pointer;
+  
+        &:hover {
+          background-color: darken(@av-bg, 6%);
+        }
+    }
 }

--- a/avBooth/show-pdf-directive/show-pdf-directive.less
+++ b/avBooth/show-pdf-directive/show-pdf-directive.less
@@ -38,7 +38,6 @@
         background-color: @av-bg;
         margin-top: 5px;
         margin-bottom: 44px;
-
     }
 
     @media (max-width: 768px) {
@@ -47,7 +46,7 @@
         }
         .navbar-unfixed-top {
             margin: 0;
-            padding-top: 0;
+            padding-top: 0 !important;
         }
     }
 

--- a/index.html
+++ b/index.html
@@ -100,6 +100,7 @@
   <script src="avBooth/selected-options-filter.js" class="app"></script>
   <script src="avBooth/count-selected-options-filter.js" class="app"></script>
   <script src="avBooth/has-selected-options-filter.js" class="app"></script>
+  <script src="avBooth/show-pdf-directive/show-pdf-directive.js" class="app"></script>
 
 
   <script src="test/test.js" class="app"></script>

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -30,6 +30,9 @@
       "body": "Està ingressant a una cabina de votació de demostració. <strong>El seu vot NO s'emetrà</strong>. Aquesta cabina de votació només té finalitats demostratius.",
       "confirm": "Accepto que el meu vot NO s'emetrà"
     },
+    "showPdf": {
+      "showPdfButton": "Mostrar PDF"
+    },
     "hashForVoteNotCastModal": {
       "header": "Vot no emès",
       "body": "Està a punt de copiar el localitzador de el vot, però <strong>el seu vot encara no s'ha emès</strong>. Si voleu buscar el localitzador de el vot, no el trobarà. Qual la raó per la que vam mostrar el localitzador de l'vot en aquest moment és perquè pugui auditar la correcció de l'vot xifrat abans d'emetre'l. Si aquesta és la raó per la qual vol copiar el localitzador de l'vot, procedeixi a copiar-lo i després auditi el seu vot.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -36,7 +36,8 @@
   "avBooth": {
     "logout": "Log out",
     "showPdf": {
-      "showPdfButton": "Show PDF"
+      "showPdfButton": "Show PDF",
+      "pdfTextDescription": "Please read the PDF before voting"
     },
     "electionChooser": {
       "hasVoted": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -35,6 +35,9 @@
   },
   "avBooth": {
     "logout": "Log out",
+    "showPdf": {
+      "showPdfButton": "Show PDF"
+    },
     "electionChooser": {
       "hasVoted": {
         "title": "Success!",

--- a/locales/es.json
+++ b/locales/es.json
@@ -37,7 +37,8 @@
   "avBooth": {
     "logout": "Cerrar sesión",
     "showPdf": {
-      "showPdfButton": "Mostrar PDF"
+      "showPdfButton": "Mostrar PDF",
+      "pdfTextDescription": "Por favor lea el PDF antes de votar"
     },
     "demoModeModal": {
       "header": "Cabina de votación de demo",

--- a/locales/es.json
+++ b/locales/es.json
@@ -36,6 +36,9 @@
   },
   "avBooth": {
     "logout": "Cerrar sesión",
+    "showPdf": {
+      "showPdfButton": "Mostrar PDF"
+    },
     "demoModeModal": {
       "header": "Cabina de votación de demo",
       "body": "Está ingresando a una cabina de votación de demostración. <strong>Su voto NO se emitirá</strong>. Esta cabina de votación solo tiene fines demostrativos.",

--- a/locales/gl.json
+++ b/locales/gl.json
@@ -29,6 +29,9 @@
         "title": "Términos legales",
         "contact": "contacto"
     },
+    "showPdf": {
+      "showPdfButton": "Mostrar PDF"
+    },
     "confirmAuditBallot": {
       "header": "¿Realmente quieres auditar tu papeleta?",
       "body": "La auditoría de la papeleta lo invalidará y tendrás que iniciar el proceso de votación de nuevo si deseas emitir tu voto. El proceso de auditoría de la papeleta permite verificar que está codificada correctamente. Hacer este proceso requiere que unos conocimientos técnicos importantes, por lo que no se recomienda si no sabes lo que estás haciendo. <br/> <br/><strong>Si lo que desea es emitir su voto, en <u>Cancelar</u> para volver a la pantalla de revisión de votación.</strong>",


### PR DESCRIPTION
# Changes
* Add new screen to show PDF.
* Change booth directive to load the screen after login in.
* Add some translations.

Previous PR: https://github.com/sequentech/voting-booth/pull/267

# Screenshots

Collapsed PDF (PC):
<img width="846" alt="Screenshot 2022-09-14 at 12 58 38" src="https://user-images.githubusercontent.com/3913223/190228254-84c0b9f2-b15d-4714-92e0-9667ba7819da.png">
Expanded PDF (PC):
<img width="847" alt="Screenshot 2022-09-14 at 12 59 15" src="https://user-images.githubusercontent.com/3913223/190228353-cb3b19ce-6cf9-4d4b-bf3e-cd3f81464d66.png">

Collapsed PDF (Mobile):
<img width="378" alt="Screenshot 2022-09-14 at 13 00 00" src="https://user-images.githubusercontent.com/3913223/190228483-fcb17451-579e-499d-9e04-612d821ffdc9.png">

Expanded PDF (Mobile):
<img width="379" alt="Screenshot 2022-09-14 at 13 00 25" src="https://user-images.githubusercontent.com/3913223/190228535-e4345d57-7db7-4366-bb2c-5e1889f1e220.png">
