### PR TITLE
Bugfix: Link to ballot tracker not working

### DIFF
--- a/avBooth/success-screen-directive/success-screen-directive.js
+++ b/avBooth/success-screen-directive/success-screen-directive.js
@@ -410,13 +410,6 @@ angular.module('avBooth')
         ) {
           var typeNumber = 0;
           var errorCorrectionLevel = 'L';
-          scope.ballotTrackerUrl = window.location.protocol + 
-            '//' + 
-            window.location.host + 
-            '/election/' + 
-            scope.election.id + 
-            '/public/ballot-locator/' + 
-            scope.stateData.ballotHash;
           var qr = QrCodeService(typeNumber, errorCorrectionLevel);
           qr.addData(scope.ballotTrackerUrl);
           qr.make();
@@ -453,6 +446,14 @@ angular.module('avBooth')
       scope.pdf = {value: null, fileName: ''};
 
       scope.successText = text({electionId: scope.election.id});
+
+      scope.ballotTrackerUrl = window.location.protocol + 
+        '//' + 
+        window.location.host + 
+        '/election/' + 
+        scope.election.id + 
+        '/public/ballot-locator/' + 
+        scope.stateData.ballotHash;
 
       generateQrCode();
 


### PR DESCRIPTION
When `election.presentation.extra_options.success_screen__hide_qr_code` is set `true`, the ballot confirmation pdf shows a link to the ballot tracker but the link didn't work. This fixes https://github.com/sequentech/roadmap/issues/40