### PR TITLE
Live preview

### DIFF
--- a/app.js
+++ b/app.js
@@ -115,7 +115,7 @@ angular.module('voting-booth').config(
           isDemo: true
         }
       })
-      .state('election.booth-demo', {
+      .state('election.booth-preview', {
         url: '/:id/preview-vote',
         templateUrl: 'avBooth/booth.html',
         controller: "BoothController",

--- a/app.js
+++ b/app.js
@@ -115,6 +115,14 @@ angular.module('voting-booth').config(
           isDemo: true
         }
       })
+      .state('election.booth-demo', {
+        url: '/:id/preview-vote',
+        templateUrl: 'avBooth/booth.html',
+        controller: "BoothController",
+        params: {
+          isPreview: true
+        }
+      })
       .state('election.public.show.home.simple', {
         template: '<div ave-simple-question></div>'
       })

--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -725,7 +725,7 @@ angular.module('avBooth')
           let ballotBoxData;
           let authapiData;
           if (scope.isPreview) {
-            var previewElection = sessionStorage.getItem(parseInt(attrs.electionId));
+            var previewElection = JSON.parse(sessionStorage.getItem(parseInt(attrs.electionId)));
             var foundElection;
             if (electionId === undefined) { 
               electionId = parseInt(attrs.electionId);

--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -725,7 +725,7 @@ angular.module('avBooth')
           let ballotBoxData;
           let authapiData;
           if (scope.isPreview) {
-            var previewElection = JSON.parse(scope.previewElection);
+            var previewElection = sessionStorage.getItem(parseInt(attrs.electionId));
             var foundElection;
             if (electionId === undefined) { 
               electionId = parseInt(attrs.electionId);
@@ -1047,9 +1047,6 @@ angular.module('avBooth')
 
         // Variable that stablishes if the election is a live preview or not.
         isPreview: (attrs.isPreview === "true"),
-
-        // Variable that stores the preview election data.
-        previewElection: (attrs.previewElection),
 
         // In case of parent-election, which children election should be loading
         // currently is set here

--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -726,10 +726,15 @@ angular.module('avBooth')
           let authapiData;
           if (scope.isPreview) {
             var previewElection = JSON.parse(scope.previewElection);
-            authapiData = ElectionCreation.generateAuthapiResponse(previewElection[0]);
-            ballotBoxData = ElectionCreation.generateBallotBoxResponse(previewElection[0]);
-            authapiData.id = scope.electionId;
-            ballotBoxData.id = scope.electionId;
+            var foundElection;
+            if (previewElection.length === 1 || electionId === undefined) {
+              foundElection = previewElection[0];
+              foundElection.id = electionId || parseInt(attrs.electionId);
+            } else {
+              foundElection = previewElection.find(function (element) { element.id === electionId});
+            }
+            authapiData = ElectionCreation.generateAuthapiResponse(foundElection);
+            ballotBoxData = ElectionCreation.generateBallotBoxResponse(foundElection);
           }
 
           let electionPromise;

--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -721,6 +721,11 @@ angular.module('avBooth')
           // process vote credentials
           readVoteCredentials();
 
+          let previewElection;
+          if (scope.isPreview) {
+            previewElection = JSON.parse(scope.previewElection);
+          }
+
           let electionPromise;
           if (!scope.isPreview) {
             electionPromise = $http.get(
@@ -735,7 +740,7 @@ angular.module('avBooth')
             deferred.resolve({
               data: {
                 payload: {
-                  configuration: scope.previewElection.ballot_box,
+                  configuration: JSON.stringify(previewElection.ballot_box),
                   state: "started",
                   pks: []
                 }
@@ -915,7 +920,7 @@ angular.module('avBooth')
             deferred.resolve({
               data: {
                 status: "ok",
-                events: scope.previewElection.authapi
+                events: previewElection.authapi
               }
             });
 

--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -725,7 +725,7 @@ angular.module('avBooth')
           var ballotBoxData;
           var authapiData;
           if (scope.isPreview) {
-            var previewElection = JSON.parse(sessionStorage.getItem(parseInt(attrs.electionId)));
+            var previewElection = JSON.parse(scope.previewElection || sessionStorage.getItem(parseInt(attrs.electionId)));
             var foundElection;
             if (electionId === undefined) { 
               electionId = parseInt(attrs.electionId);
@@ -1047,6 +1047,9 @@ angular.module('avBooth')
 
         // Variable that stablishes if the election is a live preview or not.
         isPreview: (attrs.isPreview === "true"),
+
+        // Variable that stores the preview election data.
+        previewElection: (attrs.previewElection),
 
         // In case of parent-election, which children election should be loading
         // currently is set here

--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -733,9 +733,9 @@ angular.module('avBooth')
 
             if (previewElection.length === 1) {
               foundElection = previewElection[0];
-              foundElection.id = foundElection.id || electionId;
+              foundElection.id = foundElection.id || (electionId && parseInt(electionId));
             } else {
-              foundElection = previewElection.find(function (element) { return element.id === electionId; });
+              foundElection = previewElection.find(function (element) { return element.id === parseInt(electionId); });
             }
             authapiData = ElectionCreation.generateAuthapiResponse(foundElection);
             ballotBoxData = ElectionCreation.generateBallotBoxResponse(foundElection);

--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -727,11 +727,15 @@ angular.module('avBooth')
           if (scope.isPreview) {
             var previewElection = JSON.parse(scope.previewElection);
             var foundElection;
-            if (previewElection.length === 1 || electionId === undefined) {
+            if (electionId === undefined) { 
+              electionId = parseInt(attrs.electionId);
+            }
+
+            if (previewElection.length === 1) {
               foundElection = previewElection[0];
-              foundElection.id = electionId || parseInt(attrs.electionId);
+              foundElection.id = foundElection.id || electionId;
             } else {
-              foundElection = previewElection.find(function (element) { element.id === electionId});
+              foundElection = previewElection.find(function (element) { return element.id === electionId; });
             }
             authapiData = ElectionCreation.generateAuthapiResponse(foundElection);
             ballotBoxData = ElectionCreation.generateBallotBoxResponse(foundElection);

--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -726,8 +726,8 @@ angular.module('avBooth')
           let authapiData;
           if (scope.isPreview) {
             var previewElection = JSON.parse(scope.previewElection);
-            authapiData = ElectionCreation.generateAutheventData(previewElection[0]);
-            ballotBoxData = ElectionCreation.generateElectionData(previewElection[0]);
+            authapiData = ElectionCreation.generateAuthapiResponse(previewElection[0]);
+            ballotBoxData = ElectionCreation.generateBallotBoxResponse(previewElection[0]);
             authapiData.id = scope.electionId;
             ballotBoxData.id = scope.electionId;
           }

--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -739,11 +739,7 @@ angular.module('avBooth')
 
             deferred.resolve({
               data: {
-                payload: {
-                  configuration: JSON.stringify(previewElection.ballot_box.configuration),
-                  state: "started",
-                  pks: []
-                }
+                payload: previewElection.ballot_box
               }
             });
 

--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -866,7 +866,7 @@ angular.module('avBooth')
                 // re-process vote credentials in case isVirtual changed
                 readVoteCredentials();
 
-                if (scope.isVirtual) {
+                if (scope.isVirtual || scope.isPreview) {
                   if (hasAuthapiError) {
                     showError($i18next("avBooth.errorLoadingElection"));
                     return;

--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -740,7 +740,7 @@ angular.module('avBooth')
             deferred.resolve({
               data: {
                 payload: {
-                  configuration: JSON.stringify(previewElection.ballot_box),
+                  configuration: JSON.stringify(previewElection.ballot_box.configuration),
                   state: "started",
                   pks: []
                 }
@@ -866,7 +866,7 @@ angular.module('avBooth')
                 // re-process vote credentials in case isVirtual changed
                 readVoteCredentials();
 
-                if (scope.isVirtual || scope.isPreview) {
+                if (scope.isVirtual) {
                   if (hasAuthapiError) {
                     showError($i18next("avBooth.errorLoadingElection"));
                     return;
@@ -935,7 +935,7 @@ angular.module('avBooth')
                   scope.authEvent = response.data.events;
                 }
                 execIfAllRetrieved(function () {
-                  if (scope.isVirtual || scope.isPreview) {
+                  if (scope.isVirtual) {
                     if (!scope.parentAuthEvent) {
                       scope.parentAuthEvent = angular.copy(
                         response.data.events

--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -722,8 +722,8 @@ angular.module('avBooth')
           // process vote credentials
           readVoteCredentials();
 
-          let ballotBoxData;
-          let authapiData;
+          var ballotBoxData;
+          var authapiData;
           if (scope.isPreview) {
             var previewElection = JSON.parse(sessionStorage.getItem(parseInt(attrs.electionId)));
             var foundElection;
@@ -741,7 +741,7 @@ angular.module('avBooth')
             ballotBoxData = ElectionCreation.generateBallotBoxResponse(foundElection);
           }
 
-          let electionPromise;
+          var electionPromise;
           if (!scope.isPreview) {
             electionPromise = $http.get(
               scope.baseUrl + "election/" + scope.electionId,
@@ -750,7 +750,7 @@ angular.module('avBooth')
               }
             );
           } else {
-            let deferred = $q.defer();
+            var deferred = $q.defer();
 
             deferred.resolve({
               data: {
@@ -922,11 +922,11 @@ angular.module('avBooth')
               }
             );
 
-          let authEventPromise;
+          var authEventPromise;
           if (!scope.isPreview) {
             authEventPromise = Authmethod.viewEvent(scope.electionId);
           } else {
-            let deferred = $q.defer();
+            var deferred = $q.defer();
 
             deferred.resolve({
               data: {

--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -750,15 +750,15 @@ angular.module('avBooth')
               }
             );
           } else {
-            var deferred = $q.defer();
+            var deferredElection = $q.defer();
 
-            deferred.resolve({
+            deferredElection.resolve({
               data: {
                 payload: ballotBoxData
               }
             });
 
-            electionPromise = deferred.promise;
+            electionPromise = deferredElection.promise;
           }
 
           electionPromise
@@ -926,16 +926,16 @@ angular.module('avBooth')
           if (!scope.isPreview) {
             authEventPromise = Authmethod.viewEvent(scope.electionId);
           } else {
-            var deferred = $q.defer();
+            var deferredAuthEvent = $q.defer();
 
-            deferred.resolve({
+            deferredAuthEvent.resolve({
               data: {
                 status: "ok",
                 events: authapiData
               }
             });
 
-            authEventPromise = deferred.promise;
+            authEventPromise = deferredAuthEvent.promise;
           }
 
           authEventPromise

--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -1016,6 +1016,9 @@ angular.module('avBooth')
         // Variable that stablishes if the election is a live preview or not.
         isPreview: (attrs.isPreview === "true"),
 
+        // Variable that stores the preview election data.
+        previewElection: (attrs.previewElection),
+
         // In case of parent-election, which children election should be loading
         // currently is set here
         demoElectionIndex: -1,

--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -28,6 +28,7 @@ angular.module('avBooth')
     ConfigService,
     HmacService,
     InsideIframeService,
+    ElectionCreation,
     I18nOverride
   ) {
     // we use it as something similar to a controller here
@@ -721,9 +722,13 @@ angular.module('avBooth')
           // process vote credentials
           readVoteCredentials();
 
-          let previewElection;
+          let ballotBoxData;
+          let authapiData;
           if (scope.isPreview) {
-            previewElection = JSON.parse(scope.previewElection);
+            authapiData = ElectionCreation.generateAutheventData(el);
+            ballotBoxData = ElectionCreation.generateElectionData(el);
+            authapiData.id = scope.electionId;
+            ballotBoxData.id = scope.electionId;
           }
 
           let electionPromise;
@@ -739,7 +744,7 @@ angular.module('avBooth')
 
             deferred.resolve({
               data: {
-                payload: previewElection.ballot_box
+                payload: ballotBoxData
               }
             });
 
@@ -916,7 +921,7 @@ angular.module('avBooth')
             deferred.resolve({
               data: {
                 status: "ok",
-                events: previewElection.authapi
+                events: authapiData
               }
             });
 

--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -735,7 +735,7 @@ angular.module('avBooth')
             deferred.resolve({
               data: {
                 payload: {
-                  configuration: scope.previewElection,
+                  configuration: scope.previewElection.ballot_box,
                   state: "started",
                   pks: []
                 }
@@ -906,7 +906,23 @@ angular.module('avBooth')
               }
             );
 
-          Authmethod.viewEvent(scope.electionId)
+          let authEventPromise;
+          if (!scope.isPreview) {
+            authEventPromise = Authmethod.viewEvent(scope.electionId);
+          } else {
+            let deferred = $q.defer();
+
+            deferred.resolve({
+              data: {
+                status: "ok",
+                events: scope.previewElection.authapi
+              }
+            });
+
+            authEventPromise = deferred.promise;
+          }
+
+          authEventPromise
             .then(
               function onSuccess(response) {
                 iamRetrieved = true;
@@ -914,7 +930,7 @@ angular.module('avBooth')
                   scope.authEvent = response.data.events;
                 }
                 execIfAllRetrieved(function () {
-                  if (scope.isVirtual) {
+                  if (scope.isVirtual || scope.isPreview) {
                     if (!scope.parentAuthEvent) {
                       scope.parentAuthEvent = angular.copy(
                         response.data.events

--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -725,8 +725,9 @@ angular.module('avBooth')
           let ballotBoxData;
           let authapiData;
           if (scope.isPreview) {
-            authapiData = ElectionCreation.generateAutheventData(el);
-            ballotBoxData = ElectionCreation.generateElectionData(el);
+            var previewElection = JSON.parse(scope.previewElection);
+            authapiData = ElectionCreation.generateAutheventData(previewElection);
+            ballotBoxData = ElectionCreation.generateElectionData(previewElection);
             authapiData.id = scope.electionId;
             ballotBoxData.id = scope.electionId;
           }

--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -726,8 +726,8 @@ angular.module('avBooth')
           let authapiData;
           if (scope.isPreview) {
             var previewElection = JSON.parse(scope.previewElection);
-            authapiData = ElectionCreation.generateAutheventData(previewElection);
-            ballotBoxData = ElectionCreation.generateElectionData(previewElection);
+            authapiData = ElectionCreation.generateAutheventData(previewElection[0]);
+            ballotBoxData = ElectionCreation.generateElectionData(previewElection[0]);
             authapiData.id = scope.electionId;
             ballotBoxData.id = scope.electionId;
           }

--- a/avBooth/booth-header-directive/booth-header-directive.html
+++ b/avBooth/booth-header-directive/booth-header-directive.html
@@ -97,3 +97,13 @@
     </div>
   </div>
 </div>
+
+<div class="container-fluid warning-demo" ng-if="isPreview">
+  <div class="container">
+    <div class="row">
+      <div class="col-xs-12">
+        <p ng-i18next="[html]avBooth.thisisAPreviewNotification"></p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/avBooth/booth.html
+++ b/avBooth/booth.html
@@ -2,5 +2,8 @@
   election-id="{{electionId}}"
   base-url="{{baseUrl}}"
   config="{{config}}"
-  is-demo="{{isDemo}}">
+  is-demo="{{isDemo}}"
+  is-preview="{{isPreview}}"
+  preview-election="{{previewElection}}"
+  >
 </div>

--- a/avBooth/booth.html
+++ b/avBooth/booth.html
@@ -4,6 +4,5 @@
   config="{{config}}"
   is-demo="{{isDemo}}"
   is-preview="{{isPreview}}"
-  preview-election="{{previewElection}}"
   >
 </div>

--- a/avBooth/booth.html
+++ b/avBooth/booth.html
@@ -4,5 +4,6 @@
   config="{{config}}"
   is-demo="{{isDemo}}"
   is-preview="{{isPreview}}"
+  preview-election="{{previewElection}}"
   >
 </div>

--- a/avBooth/booth.js
+++ b/avBooth/booth.js
@@ -41,13 +41,10 @@ angular
       ConfigService, 
       $i18next, 
       $cookies,
-      $location,
       InsideIframeService
     ) {
       $scope.isDemo = $stateParams.isDemo || false;
-      var previewElectionParam = ($location.search())['preview-election'];
-      $scope.previewElection = previewElectionParam && decodeURIComponent(previewElectionParam);
-      $scope.isPreview = $stateParams.isPreview && _.isString($scope.previewElection) || false;
+      $scope.isPreview = $stateParams.isPreview || false;
       $scope.electionId = $stateParams.id;
       $scope.baseUrl = ConfigService.baseUrl;
       $scope.config = $filter('json')(ConfigService);

--- a/avBooth/booth.js
+++ b/avBooth/booth.js
@@ -45,7 +45,8 @@ angular
       InsideIframeService
     ) {
       $scope.isDemo = $stateParams.isDemo || false;
-      $scope.previewElection = ($location.search())['preview-election'];
+      var previewElectionParam = ($location.search())['preview-election'];
+      $scope.previewElection = previewElectionParam && decodeURIComponent(previewElectionParam);
       $scope.isPreview = $stateParams.isPreview && _.isString($scope.previewElection) || false;
       $scope.electionId = $stateParams.id;
       $scope.baseUrl = ConfigService.baseUrl;

--- a/avBooth/booth.js
+++ b/avBooth/booth.js
@@ -41,9 +41,12 @@ angular
       ConfigService, 
       $i18next, 
       $cookies,
+      $location,
       InsideIframeService
     ) {
       $scope.isDemo = $stateParams.isDemo || false;
+      var previewElectionParam = ($location.search())['preview-election'];
+      $scope.previewElection = previewElectionParam && decodeURIComponent(previewElectionParam);
       $scope.isPreview = $stateParams.isPreview || false;
       $scope.electionId = $stateParams.id;
       $scope.baseUrl = ConfigService.baseUrl;

--- a/avBooth/booth.js
+++ b/avBooth/booth.js
@@ -46,7 +46,7 @@ angular
     ) {
       $scope.isDemo = $stateParams.isDemo || false;
       $scope.previewElection = ($location.search())['preview-election'];
-      $scope.isPreview = $stateParams.isPreview && _.isObject($scope.previewElection) || false;
+      $scope.isPreview = $stateParams.isPreview && _.isString($scope.previewElection) || false;
       $scope.electionId = $stateParams.id;
       $scope.baseUrl = ConfigService.baseUrl;
       $scope.config = $filter('json')(ConfigService);

--- a/avBooth/booth.js
+++ b/avBooth/booth.js
@@ -41,10 +41,12 @@ angular
       ConfigService, 
       $i18next, 
       $cookies,
+      $location,
       InsideIframeService
     ) {
       $scope.isDemo = $stateParams.isDemo || false;
-      $scope.isPreview = $stateParams.isPreview || false;
+      $scope.previewElection = ($location.search())['preview-election'];
+      $scope.isPreview = $stateParams.isPreview && _.isObject($scope.previewElection) || false;
       $scope.electionId = $stateParams.id;
       $scope.baseUrl = ConfigService.baseUrl;
       $scope.config = $filter('json')(ConfigService);

--- a/avBooth/booth.js
+++ b/avBooth/booth.js
@@ -44,6 +44,7 @@ angular
       InsideIframeService
     ) {
       $scope.isDemo = $stateParams.isDemo || false;
+      $scope.isPreview = $stateParams.isPreview || false;
       $scope.electionId = $stateParams.id;
       $scope.baseUrl = ConfigService.baseUrl;
       $scope.config = $filter('json')(ConfigService);

--- a/avBooth/election-chooser-screen-directive/election-chooser-screen-directive.js
+++ b/avBooth/election-chooser-screen-directive/election-chooser-screen-directive.js
@@ -69,7 +69,7 @@ angular.module('avBooth')
             var credentials = getElectionCredentials();
 
             // if it's a demo, yes, allow voting by default
-            scope.canVote = scope.isDemo;
+            scope.canVote = scope.isDemo || scope.isPreview;
             scope.hasVoted = false;
             scope.skippedElections = [];
             childrenInfo.presentation.categories = _.map(
@@ -97,8 +97,8 @@ angular.module('avBooth')
                                 election,
                                 elCredentials || {},
                                 {
-                                    disabled: (!scope.isDemo && !canVote),
-                                    hidden: (!scope.isDemo && !isVoter)
+                                    disabled: (!scope.isDemo && !scope.isPreview && !canVote),
+                                    hidden: (!scope.isDemo && !scope.isPreview && !isVoter)
                                 }
                             );
                             if (!!retValue.skipped) {

--- a/locales/en.json
+++ b/locales/en.json
@@ -230,6 +230,8 @@
 
 
     "thisisADemoNotification": "<span class=\"glyphicon glyphicon-info-sign\" aria-hidden=\"true\"></span> <strong>Warning!</strong> Demo voting booth, votes issued from this booth will not count.",
+
+    "thisisAPreviewNotification": "<span class=\"glyphicon glyphicon-info-sign\" aria-hidden=\"true\"></span> <strong>Warning!</strong> Preview voting booth, votes issued from this booth will not count.",
     "successBallotHash": "You have cast your ballot with <strong><a href=\"__url__\" target=\"_blank\">__name__</a></strong>. The ballot tracker of your ballot is:<br/><br/></h3><a href=\"__ballotLocatorUrl__\" target=\"__target__\"><strong>__ballotHash__</strong></a><br/><br/>You can use your ballot tracker to verify that your ballot has been correctly cast <strong><a href=\"__ballotLocatorUrl__\" target=\"__target__\">using this address</a></strong>.",
     "qrCodeAlt": "QR Code",
     "successBallotQrCode": "You can verify your ballot has been correctly cast using the following QR Code:",

--- a/locales/en.json
+++ b/locales/en.json
@@ -59,6 +59,11 @@
       "body": "You are entering a demo voting booth. <strong>Your vote will NOT be cast</strong>. This voting booth is for demonstration purposes only.",
       "confirm": "I accept my vote will NOT be cast"
     },
+    "previewModeModal": {
+      "header": "Live Preview voting booth",
+      "body": "You are entering a live preview voting booth. <strong>Your vote will NOT be cast</strong>. This voting booth is for demonstration purposes only.",
+      "confirm": "I accept my vote will NOT be cast"
+    },
     "hashForVoteNotCastModal": {
       "header": "Vote has not been cast",
       "body": "You are about to copy the ballot tracker id, but <strong>your vote has not been cast yet</strong>. If you try to track the ballot, you will not find it.<br><br>The reason we show the ballot tracker id at this stage is to allow you to audit the correctness of the encrypted ballot before casting it. If that's why you want to copy the tracker id, please proceed to copy it and then proceed to audit the vote.",

--- a/locales/es.json
+++ b/locales/es.json
@@ -45,6 +45,11 @@
       "body": "Está ingresando a una cabina de votación de demostración. <strong>Su voto NO se emitirá</strong>. Esta cabina de votación solo tiene fines demostrativos.",
       "confirm": "Acepto que mi voto NO se emitirá"
     },
+    "previewModeModal": {
+      "header": "Previsualización de cabina de votación",
+      "body": "Está ingresando a una cabina de votación de demostración. <strong>Su voto NO se emitirá</strong>. Esta cabina de votación solo tiene fines demostrativos.",
+      "confirm": "Acepto que mi voto NO se emitirá"
+    },
     "hashForVoteNotCastModal": {
       "header": "Voto no emitido",
       "body": "Está a punto de copiar el localizador del voto, pero <strong>su voto aún no se ha emitido</strong>. Si intenta buscar el localizador del voto, no lo encontrará. <br> <br> La razón por la que mostramos el localizador del voto en este momento es para que pueda auditar la corrección del voto cifrado antes de emitirlo. Si esa es la razón por la que desea copiar el localizador del voto, proceda a copiarlo y luego audite su voto.",

--- a/locales/es.json
+++ b/locales/es.json
@@ -206,6 +206,7 @@
     "auditStartAgain": "Comenzar el proceso de voto de nuevo",
 
     "thisisADemoNotification": "<span class=\"glyphicon glyphicon-info-sign\" aria-hidden=\"true\"></span> <strong>¡Atención!</strong> Cabina de votación de prueba, los votos emitidos aquí no cuentan.",
+    "thisisAPreviewNotification": "<span class=\"glyphicon glyphicon-info-sign\" aria-hidden=\"true\"></span> <strong>¡Atención!</strong> Cabina de votación de previsualización, los votos emitidos aquí no cuentan.",
     "successBallotHash": "Ha emitido su voto con <strong><a href=\"__url__\" target=\"_blank\">__name__</a></strong>. El localizador de su voto es:<br/><br/></h3><a href=\"__ballotLocatorUrl__\" target=\"__target__\"><strong>__ballotHash__</strong></a><br/><br/>Puede usar su localizador para verificar que su voto ha quedado registrado en <strong><a href=\"__ballotLocatorUrl__\" target=\"__target__\">esta dirección</a></strong>.",
     "qrCodeAlt": "Código QR",
     "successBallotQrCode": "Puede verificar que su voto ha quedado registrado mediante el siguiente código QR:",


### PR DESCRIPTION
The `Live Preview`feature allows election admins to see the voting booth before creating the election. For the voting booth, this means the election data is not received from the backend server but either through the URL or the session storage.

# Changes
* Add a new state for the preview election url: `'/:id/preview-vote`.
* Read the election data either from the query param `` or the session storage key `:id` (same id as in the URL).
* The format of the election data is the same as the [Election Creation JSON.](https://sequentech.github.io/documentation/docs/general/reference/election-creation-json/).
* The preview vote screen shows a banner and a modal warning that the ballot won't be cast. Spanish and English translations included.