### PR TITLE
Live preview (#284)

### DIFF
--- a/app.js
+++ b/app.js
@@ -115,6 +115,14 @@ angular.module('voting-booth').config(
           isDemo: true
         }
       })
+      .state('election.booth-preview', {
+        url: '/:id/preview-vote',
+        templateUrl: 'avBooth/booth.html',
+        controller: "BoothController",
+        params: {
+          isPreview: true
+        }
+      })
       .state('election.public.show.home.simple', {
         template: '<div ave-simple-question></div>'
       })

--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -17,6 +17,7 @@
 
 angular.module('avBooth')
   .directive('avBooth', function(
+    $q,
     $modal,
     $cookies,
     $http,
@@ -27,6 +28,7 @@ angular.module('avBooth')
     ConfigService,
     HmacService,
     InsideIframeService,
+    ElectionCreation,
     I18nOverride
   ) {
     // we use it as something similar to a controller here
@@ -41,6 +43,7 @@ angular.module('avBooth')
       // when we are not inside an iframe and voter id is not set, this is a
       // demo booth
       scope.isDemo = (attrs.isDemo === "true");
+      scope.isPreview = (attrs.isPreview === "true");
       scope.documentation = ConfigService.documentation;
       scope.hasSeenStartScreenInThisSession = false;
 
@@ -218,7 +221,7 @@ angular.module('avBooth')
       autoredirectToLoginAfterTimeout();
 
       function checkCookies(electionId) {
-        if (scope.isDemo) {
+        if (scope.isDemo || scope.isPreview) {
           return;
         }
 
@@ -487,7 +490,7 @@ angular.module('avBooth')
         {
           if (!scope.stateData.auditClicked) {
             // in a demo, we don't send the ballot, we just show as if we had sent it
-            if (scope.isDemo) {
+            if (scope.isDemo || scope.isPreview) {
               scope.setState(stateEnum.successScreen, {
                 ballotHash: scope.stateData.ballotHash,
                 ballotResponse: {
@@ -618,7 +621,7 @@ angular.module('avBooth')
 
       // Try to read and process voting credentials
       function readVoteCredentials() {
-        if (scope.isDemo) {
+        if (scope.isDemo || scope.isPreview) {
           return;
         }
         var credentialsStr = $window.sessionStorage.getItem("vote_permission_tokens");
@@ -719,12 +722,46 @@ angular.module('avBooth')
           // process vote credentials
           readVoteCredentials();
 
-          $http.get(
-            scope.baseUrl + "election/" + scope.electionId,
-            {
-              headers: {'Authorization': scope.authorizationHeader || null}
+          var ballotBoxData;
+          var authapiData;
+          if (scope.isPreview) {
+            var previewElection = JSON.parse(scope.previewElection || sessionStorage.getItem(parseInt(attrs.electionId)));
+            var foundElection;
+            if (electionId === undefined) { 
+              electionId = parseInt(attrs.electionId);
             }
-          )
+
+            if (previewElection.length === 1) {
+              foundElection = previewElection[0];
+              foundElection.id = foundElection.id || (electionId && parseInt(electionId));
+            } else {
+              foundElection = previewElection.find(function (element) { return element.id === parseInt(electionId); });
+            }
+            authapiData = ElectionCreation.generateAuthapiResponse(foundElection);
+            ballotBoxData = ElectionCreation.generateBallotBoxResponse(foundElection);
+          }
+
+          var electionPromise;
+          if (!scope.isPreview) {
+            electionPromise = $http.get(
+              scope.baseUrl + "election/" + scope.electionId,
+              {
+                headers: {'Authorization': scope.authorizationHeader || null}
+              }
+            );
+          } else {
+            var deferredElection = $q.defer();
+
+            deferredElection.resolve({
+              data: {
+                payload: ballotBoxData
+              }
+            });
+
+            electionPromise = deferredElection.promise;
+          }
+
+          electionPromise
             .then(
               function onSuccess(response) {
                 scope.election = angular.fromJson(response.data.payload.configuration);
@@ -770,6 +807,7 @@ angular.module('avBooth')
 
                 // global variables
                 $window.isDemo = scope.isDemo;
+                $window.isPreview = scope.isPreview;
                 $window.election = scope.election;
 
                 // index questions
@@ -802,6 +840,30 @@ angular.module('avBooth')
                           header: "avBooth.demoModeModal.header",
                           body: "avBooth.demoModeModal.body",
                           continue: "avBooth.demoModeModal.confirm"
+                        };
+                      }
+                    }
+                  });
+                }
+
+                // If it's a live preview booth and we are at this stage, ensure to
+                // show the modal "this is a live preview booth" warning
+                if (scope.isPreview && !scope.shownIsPreviewModal) {
+                  scope.shownIsPreviewModal = true;
+                  $modal.open({
+                    ariaLabelledBy: 'modal-title',
+                    ariaDescribedBy: 'modal-body',
+                    templateUrl: "avBooth/invalid-answers-controller/invalid-answers-controller.html",
+                    controller: "InvalidAnswersController",
+                    size: 'md',
+                    resolve: {
+                      errors: function() { return []; },
+                      data: function() {
+                        return {
+                          errors: [],
+                          header: "avBooth.previewModeModal.header",
+                          body: "avBooth.previewModeModal.body",
+                          continue: "avBooth.previewModeModal.confirm"
                         };
                       }
                     }
@@ -860,7 +922,23 @@ angular.module('avBooth')
               }
             );
 
-          Authmethod.viewEvent(scope.electionId)
+          var authEventPromise;
+          if (!scope.isPreview) {
+            authEventPromise = Authmethod.viewEvent(scope.electionId);
+          } else {
+            var deferredAuthEvent = $q.defer();
+
+            deferredAuthEvent.resolve({
+              data: {
+                status: "ok",
+                events: authapiData
+              }
+            });
+
+            authEventPromise = deferredAuthEvent.promise;
+          }
+
+          authEventPromise
             .then(
               function onSuccess(response) {
                 iamRetrieved = true;
@@ -966,6 +1044,12 @@ angular.module('avBooth')
 
         // Variable that stablishes if the election is a demo or not.
         isDemo: (attrs.isDemo === "true"),
+
+        // Variable that stablishes if the election is a live preview or not.
+        isPreview: (attrs.isPreview === "true"),
+
+        // Variable that stores the preview election data.
+        previewElection: (attrs.previewElection),
 
         // In case of parent-election, which children election should be loading
         // currently is set here

--- a/avBooth/booth-header-directive/booth-header-directive.html
+++ b/avBooth/booth-header-directive/booth-header-directive.html
@@ -97,3 +97,13 @@
     </div>
   </div>
 </div>
+
+<div class="container-fluid warning-demo" ng-if="isPreview">
+  <div class="container">
+    <div class="row">
+      <div class="col-xs-12">
+        <p ng-i18next="[html]avBooth.thisisAPreviewNotification"></p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/avBooth/booth.html
+++ b/avBooth/booth.html
@@ -2,5 +2,8 @@
   election-id="{{electionId}}"
   base-url="{{baseUrl}}"
   config="{{config}}"
-  is-demo="{{isDemo}}">
+  is-demo="{{isDemo}}"
+  is-preview="{{isPreview}}"
+  preview-election="{{previewElection}}"
+  >
 </div>

--- a/avBooth/booth.js
+++ b/avBooth/booth.js
@@ -41,9 +41,13 @@ angular
       ConfigService, 
       $i18next, 
       $cookies,
+      $location,
       InsideIframeService
     ) {
       $scope.isDemo = $stateParams.isDemo || false;
+      var previewElectionParam = ($location.search())['preview-election'];
+      $scope.previewElection = previewElectionParam && decodeURIComponent(previewElectionParam);
+      $scope.isPreview = $stateParams.isPreview || false;
       $scope.electionId = $stateParams.id;
       $scope.baseUrl = ConfigService.baseUrl;
       $scope.config = $filter('json')(ConfigService);

--- a/avBooth/election-chooser-screen-directive/election-chooser-screen-directive.js
+++ b/avBooth/election-chooser-screen-directive/election-chooser-screen-directive.js
@@ -69,7 +69,7 @@ angular.module('avBooth')
             var credentials = getElectionCredentials();
 
             // if it's a demo, yes, allow voting by default
-            scope.canVote = scope.isDemo;
+            scope.canVote = scope.isDemo || scope.isPreview;
             scope.hasVoted = false;
             scope.skippedElections = [];
             childrenInfo.presentation.categories = _.map(
@@ -97,8 +97,8 @@ angular.module('avBooth')
                                 election,
                                 elCredentials || {},
                                 {
-                                    disabled: (!scope.isDemo && !canVote),
-                                    hidden: (!scope.isDemo && !isVoter)
+                                    disabled: (!scope.isDemo && !scope.isPreview && !canVote),
+                                    hidden: (!scope.isDemo && !scope.isPreview && !isVoter)
                                 }
                             );
                             if (!!retValue.skipped) {

--- a/locales/en.json
+++ b/locales/en.json
@@ -59,6 +59,11 @@
       "body": "You are entering a demo voting booth. <strong>Your vote will NOT be cast</strong>. This voting booth is for demonstration purposes only.",
       "confirm": "I accept my vote will NOT be cast"
     },
+    "previewModeModal": {
+      "header": "Live Preview voting booth",
+      "body": "You are entering a live preview voting booth. <strong>Your vote will NOT be cast</strong>. This voting booth is for demonstration purposes only.",
+      "confirm": "I accept my vote will NOT be cast"
+    },
     "hashForVoteNotCastModal": {
       "header": "Vote has not been cast",
       "body": "You are about to copy the ballot tracker id, but <strong>your vote has not been cast yet</strong>. If you try to track the ballot, you will not find it.<br><br>The reason we show the ballot tracker id at this stage is to allow you to audit the correctness of the encrypted ballot before casting it. If that's why you want to copy the tracker id, please proceed to copy it and then proceed to audit the vote.",
@@ -230,6 +235,8 @@
 
 
     "thisisADemoNotification": "<span class=\"glyphicon glyphicon-info-sign\" aria-hidden=\"true\"></span> <strong>Warning!</strong> Demo voting booth, votes issued from this booth will not count.",
+
+    "thisisAPreviewNotification": "<span class=\"glyphicon glyphicon-info-sign\" aria-hidden=\"true\"></span> <strong>Warning!</strong> Preview voting booth, votes issued from this booth will not count.",
     "successBallotHash": "You have cast your ballot with <strong><a href=\"__url__\" target=\"_blank\">__name__</a></strong>. The ballot tracker of your ballot is:<br/><br/></h3><a href=\"__ballotLocatorUrl__\" target=\"__target__\"><strong>__ballotHash__</strong></a><br/><br/>You can use your ballot tracker to verify that your ballot has been correctly cast <strong><a href=\"__ballotLocatorUrl__\" target=\"__target__\">using this address</a></strong>.",
     "qrCodeAlt": "QR Code",
     "successBallotQrCode": "You can verify your ballot has been correctly cast using the following QR Code:",

--- a/locales/es.json
+++ b/locales/es.json
@@ -45,6 +45,11 @@
       "body": "Está ingresando a una cabina de votación de demostración. <strong>Su voto NO se emitirá</strong>. Esta cabina de votación solo tiene fines demostrativos.",
       "confirm": "Acepto que mi voto NO se emitirá"
     },
+    "previewModeModal": {
+      "header": "Previsualización de cabina de votación",
+      "body": "Está ingresando a una cabina de votación de demostración. <strong>Su voto NO se emitirá</strong>. Esta cabina de votación solo tiene fines demostrativos.",
+      "confirm": "Acepto que mi voto NO se emitirá"
+    },
     "hashForVoteNotCastModal": {
       "header": "Voto no emitido",
       "body": "Está a punto de copiar el localizador del voto, pero <strong>su voto aún no se ha emitido</strong>. Si intenta buscar el localizador del voto, no lo encontrará. <br> <br> La razón por la que mostramos el localizador del voto en este momento es para que pueda auditar la corrección del voto cifrado antes de emitirlo. Si esa es la razón por la que desea copiar el localizador del voto, proceda a copiarlo y luego audite su voto.",
@@ -206,6 +211,7 @@
     "auditStartAgain": "Comenzar el proceso de voto de nuevo",
 
     "thisisADemoNotification": "<span class=\"glyphicon glyphicon-info-sign\" aria-hidden=\"true\"></span> <strong>¡Atención!</strong> Cabina de votación de prueba, los votos emitidos aquí no cuentan.",
+    "thisisAPreviewNotification": "<span class=\"glyphicon glyphicon-info-sign\" aria-hidden=\"true\"></span> <strong>¡Atención!</strong> Cabina de votación de previsualización, los votos emitidos aquí no cuentan.",
     "successBallotHash": "Ha emitido su voto con <strong><a href=\"__url__\" target=\"_blank\">__name__</a></strong>. El localizador de su voto es:<br/><br/></h3><a href=\"__ballotLocatorUrl__\" target=\"__target__\"><strong>__ballotHash__</strong></a><br/><br/>Puede usar su localizador para verificar que su voto ha quedado registrado en <strong><a href=\"__ballotLocatorUrl__\" target=\"__target__\">esta dirección</a></strong>.",
     "qrCodeAlt": "Código QR",
     "successBallotQrCode": "Puede verificar que su voto ha quedado registrado mediante el siguiente código QR:",


### PR DESCRIPTION
The `Live Preview`feature allows election admins to see the voting booth before creating the election. For the voting booth, this means the election data is not received from the backend server but either through the URL or the session storage.

# Changes
* Add a new state for the preview election url: `'/:id/preview-vote`.
* Read the election data either from the query param `` or the session storage key `:id` (same id as in the URL).
* The format of the election data is the same as the [Election Creation JSON.](https://sequentech.github.io/documentation/docs/general/reference/election-creation-json/).
* The preview vote screen shows a banner and a modal warning that the ballot won't be cast. Spanish and English translations included.