### PR TITLE
 Fix accessibility issues

### DIFF
--- a/avBooth/accordion-option-directive/accordion-option-directive.less
+++ b/avBooth/accordion-option-directive/accordion-option-directive.less
@@ -175,8 +175,8 @@
     background-color: @av-secondary;
 
 
-    a.btn-right {
-      color: white;
+    a {
+      color: @av-primary;
       background-color: transparent;
     }
   }

--- a/avBooth/booth-directive/booth-directive.js
+++ b/avBooth/booth-directive/booth-directive.js
@@ -197,6 +197,11 @@ angular.module('avBooth')
       // After cookies expires, redirect to login. But only if cookies do
       // expire.
       function autoredirectToLoginAfterTimeout() {
+        // demo and live preview don't need to expire
+        if (scope.isDemo || scope.isPreview) {
+          return;
+        }
+
         var election = (
           (!!scope.parentElection) ?
           scope.parentElection :
@@ -212,10 +217,36 @@ angular.module('avBooth')
             !election.presentation.extra_options.booth_log_out__disable
           )
         ) {
+          var minutes = ConfigService.cookies.expires;
           setTimeout(
             function () { logoutAndRedirect( /* isSuccess */ false); },
-            60*1000*ConfigService.cookies.expires
+            60*1000*minutes
           );
+
+          setTimeout(
+            function () {
+              $modal.open({
+                ariaLabelledBy: 'modal-title',
+                ariaDescribedBy: 'modal-body',
+                templateUrl: "avBooth/invalid-answers-controller/invalid-answers-controller.html",
+                controller: "InvalidAnswersController",
+                size: 'sm',
+                resolve: {
+                  errors: function() { return []; },
+                  data: function() {
+                    return {
+                      errors: [],
+                      header: "avBooth.logoutWarnModal.header",
+                      body: "avBooth.logoutWarnModal.body",
+                      continue: "avBooth.logoutWarnModal.confirm"
+                    };
+                  }
+                }
+              });
+            },
+            60*1000*(minutes - 1)
+          );
+
         }
       }
       autoredirectToLoginAfterTimeout();

--- a/avBooth/booth-header-directive/booth-header-directive.html
+++ b/avBooth/booth-header-directive/booth-header-directive.html
@@ -9,7 +9,7 @@
       <div class="col-xs-12 col-sm-4" ng-if="election.logo_url">
         <span>
           <img
-            alt="Logo Image"
+            alt="Organization Logo"
             class="logo-img" 
             ng-src="{{election.logo_url}}"
           />

--- a/avBooth/booth.less
+++ b/avBooth/booth.less
@@ -32,3 +32,7 @@ code {
       margin-left: 12px;
     }
 }
+
+#no-js {
+    color: black;
+}

--- a/avBooth/conditional-accordion-screen-directive/conditional-accordion-screen-directive.html
+++ b/avBooth/conditional-accordion-screen-directive/conditional-accordion-screen-directive.html
@@ -41,7 +41,7 @@
               id="filter-input"
               ng-model="stateData.filter"
               ng-model-options="{debounce: 500}"
-              ng-i18next="[placeholder]avBooth.filterOptionsPlaceholder"
+              ng-i18next="[placeholder]avBooth.filterOptionsPlaceholder;[aria-label]avBooth.filterOptionsPlaceholder"
               />
             <span class="glyphicon glyphicon-search"></span>
           </div>
@@ -59,7 +59,7 @@
             id="filter-input"
             ng-model="stateData.filter"
             ng-model-options="{debounce: 500}"
-            ng-i18next="[placeholder]avBooth.filterOptionsPlaceholder"
+            ng-i18next="[placeholder]avBooth.filterOptionsPlaceholder;[aria-label]avBooth.filterOptionsPlaceholder"
             />
           <span class="glyphicon glyphicon-search"></span>
         </div>

--- a/avBooth/election-chooser-screen-directive/election-chooser-screen-directive.html
+++ b/avBooth/election-chooser-screen-directive/election-chooser-screen-directive.html
@@ -24,7 +24,7 @@
           ng-if="showSkippedElections || (!canVote && hasVoted)"
           class="padded col-md-6 col-md-offset-3 cannot-vote col-xs-12"
         >
-          <h3 ng-i18next>avBooth.electionChooser.hasVoted.title</h3>
+          <h2 ng-i18next>avBooth.electionChooser.hasVoted.title</h2>
           <p
             ng-if="skippedElections.length === 0"
             ng-i18next="avBooth.electionChooser.hasVoted.description"
@@ -41,14 +41,14 @@
           ng-if="!showSkippedElections && (!canVote && !hasVoted)"
           class="padded col-xs-12 cannot-vote"
         >
-          <h3 ng-i18next>avBooth.electionChooser.cannotVote.title</h3>
+          <h2 ng-i18next>avBooth.electionChooser.cannotVote.title</h2>
           <p ng-i18next="avBooth.electionChooser.cannotVote.description"></p>
         </div>
         <div
           ng-if="!showSkippedElections && canVote"
           class="padded col-xs-12 can-vote"
         >
-          <h3 ng-i18next>avBooth.electionChooser.canVote.title</h3>
+          <h2 ng-i18next>avBooth.electionChooser.canVote.title</h2>
           <p ng-i18next="avBooth.electionChooser.canVote.description"></p>
         </div>
         <div

--- a/avBooth/election-chooser-screen-directive/election-chooser-screen-directive.less
+++ b/avBooth/election-chooser-screen-directive/election-chooser-screen-directive.less
@@ -12,4 +12,8 @@
     .election-description {
         word-break: keep-all;
     }
+
+    h2 {
+        font-size: 24px;
+    }
 }

--- a/avBooth/encrypting-ballot-screen-directive/encrypting-ballot-screen-directive.html
+++ b/avBooth/encrypting-ballot-screen-directive/encrypting-ballot-screen-directive.html
@@ -11,7 +11,7 @@
 </div>
 
 <div class="busy-gui container" ng-if="imagesPreloaded">
-  <div class="col-sm-offset-3 col-sm-6 margin-tb-15">
+  <div class="col-sm-offset-3 col-sm-6 margin-tb-15" aria-hidden="true">
     <div class="busy-img-central text-center" id="img-central">
         <div id="div-id-one">
         </div>
@@ -21,7 +21,7 @@
   </div>
   <div class="busy-text">
     <div class="col-sm-offset-3 col-sm-6 col-xs-12">
-      <h1 class="text-center" ng-i18next="avBooth.busy.title">
+      <h1 class="text-center" ng-i18next="avBooth.busy.title" aria-label="{{ ariaDescription }}">
       </h1>
     </div>
     <div

--- a/avBooth/encrypting-ballot-screen-directive/encrypting-ballot-screen-directive.js
+++ b/avBooth/encrypting-ballot-screen-directive/encrypting-ballot-screen-directive.js
@@ -39,6 +39,7 @@ angular.module('avBooth')
     ];
 
     scope.organization = ConfigService.organization;
+    scope.ariaDescription = $i18next("avBooth.busy.description");
 
     scope.stepList = [
       {

--- a/avBooth/invalid-answers-controller/invalid-answers-controller.html
+++ b/avBooth/invalid-answers-controller/invalid-answers-controller.html
@@ -38,7 +38,7 @@
   </div>
   <div class="modal-footer">
     <button 
-      tabindex="1"
+      tabindex="0"
       ng-if="data.continue" 
       class="btn btn-warning" 
       ng-click="ok()" 
@@ -47,7 +47,7 @@
       {{data.continue}}
     </button>
     <button 
-      tabindex="2"
+      tabindex="0"
       ng-if="data.cancel" 
       class="btn" 
       ng-click="cancel()" 

--- a/avBooth/multi-question-directive/multi-question-directive.html
+++ b/avBooth/multi-question-directive/multi-question-directive.html
@@ -44,7 +44,7 @@
               id="filter-input"
               ng-model="stateData.filter"
               ng-model-options="{debounce: 500}"
-              ng-i18next="[placeholder]avBooth.filterOptionsPlaceholder"
+              ng-i18next="[placeholder]avBooth.filterOptionsPlaceholder;[aria-label]avBooth.filterOptionsPlaceholder"
               />
             <span class="glyphicon glyphicon-search"></span>
           </div>
@@ -62,7 +62,7 @@
             id="filter-input"
             ng-model="stateData.filter"
             ng-model-options="{debounce: 500}"
-            ng-i18next="[placeholder]avBooth.filterOptionsPlaceholder"
+            ng-i18next="[placeholder]avBooth.filterOptionsPlaceholder;[aria-label]avBooth.filterOptionsPlaceholder"
             />
           <span class="glyphicon glyphicon-search"></span>
         </div>

--- a/avBooth/pairwise-beta-directive/pairwise-beta-directive.html
+++ b/avBooth/pairwise-beta-directive/pairwise-beta-directive.html
@@ -9,7 +9,7 @@
       <div class="col-md-4">
         <span ng-if="election.logo_url">
           <img
-            alt="Logo Image"
+            alt="Organization Logo"
             class="logo-img" 
             ng-src="{{election.logo_url}}"
           />

--- a/avBooth/pcandidates-election-screen-directive/pcandidates-election-screen-directive.html
+++ b/avBooth/pcandidates-election-screen-directive/pcandidates-election-screen-directive.html
@@ -40,7 +40,7 @@
             id="filter-input"
             ng-model="stateData.filter"
             av-debounce="500"
-            ng-i18next="[placeholder]avBooth.filterOptionsPlaceholder2"
+            ng-i18next="[placeholder]avBooth.filterOptionsPlaceholder2;[aria-label]avBooth.filterOptionsPlaceholder2"
             />
         </div>
         <div

--- a/avBooth/review-ballot-directive/review-ballot-directive.html
+++ b/avBooth/review-ballot-directive/review-ballot-directive.html
@@ -2,6 +2,7 @@
   class="question padded"
   ng-repeat="question in election.questions"
   ng-if="!question.disabled && question.disabled !== true"
+  aria-label="{{ editActionText }}"
   ng-click="goToQuestion($index, true)">
 
   <!-- title -->
@@ -10,9 +11,9 @@
       <span>{{$index + 1}}.</span>
       <span class="question-title title-text" ng-bind-html="question.title"></span>
     </h3>
-    <h3>
+    <span class="edit-btn">
       <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
-    </h3>
+    </span>
   </div>
   <p
     class="question-description"

--- a/avBooth/review-ballot-directive/review-ballot-directive.js
+++ b/avBooth/review-ballot-directive/review-ballot-directive.js
@@ -21,7 +21,7 @@
  * Shows a list with question and user answers.
  */
 angular.module('avBooth')
-  .directive('avbReviewBallot', function()
+  .directive('avbReviewBallot', function($i18next)
   {
     var link = function(scope, element, attrs)
     {
@@ -111,6 +111,8 @@ angular.module('avBooth')
           }
         }[question.tally_type]();
       };
+
+      scope.editActionText = $i18next('avBooth.reviewScreen.editAction');
     };
 
     return {

--- a/avBooth/review-ballot-directive/review-ballot-directive.less
+++ b/avBooth/review-ballot-directive/review-ballot-directive.less
@@ -26,6 +26,13 @@
       padding-top: 20px;
     }
 
+    .title-container .edit-btn {
+      margin-top: 0;
+      padding-top: 20px;
+      margin-bottom: 10px;
+      font-size: 24px;
+    }
+
     .selected-answer,
     .question-title,
     .question-description {

--- a/avBooth/simultaneous-question-answer-directive/simultaneous-question-answer-directive.html
+++ b/avBooth/simultaneous-question-answer-directive/simultaneous-question-answer-directive.html
@@ -70,11 +70,11 @@
         ng-if="!isWriteIn" 
         class="vertilize-col vert-align-top answer-texts"
       >
-        <label 
+        <span 
           id="question_{{question.index}}_answer_{{answer.id}}"
           class="answer-text" 
           ng-bind-html="answer.text"
-        ></label>
+        ></span>
         <p
           ng-if="answer.details && answer.details.length > 1"
           class="answer-details"

--- a/avBooth/simultaneous-question-answer-directive/simultaneous-question-answer-directive.html
+++ b/avBooth/simultaneous-question-answer-directive/simultaneous-question-answer-directive.html
@@ -3,19 +3,20 @@
   ng-class="{'is-category-list': isCategoryList}"
 >
   <div
-    tabindex="0"
     role="checkbox"
+    tabindex="-1"
     aria-checked="{{answer.selected > -1 ? 'true' : 'false'}}"
     aria-labelledby="question_{{question.index}}_answer_{{answer.id}}"
     class="opt vertilize-wrapper"
-    ng-click="!isWriteIn && toggleSelectItem(question, answer)"
+    ng-click="!isWriteIn && question.tally_type === 'plurality-at-large' && toggleSelectItem(question, answer)"
   >
     <div class="vertilize">
       <!-- show checkbox icon -->
       <div class="vertilize-col answer-glyphicon">
         <span 
           class="glyphicon"
-          aria-hidden="true"
+          tabindex="0"
+          aria-labelledby="question_{{question.index}}_answer_{{answer.id}}"
           ng-if="question.tally_type === 'plurality-at-large'"
           ng-click="isWriteIn && toggleSelectItem(question, answer)"
           ng-class="{
@@ -29,7 +30,7 @@
           tabindex="0"
           role="checkbox"
           ng-if="!isInvalidVoteAnswer && question.tally_type === 'cumulative'"
-          aria-labelledby="question_{{question.index}}_answer_{{answer.id}}"
+          aria-label="{{answer.text}} {{isWriteIn && 'write in ' || ''}}check {{check + 1}}"
           ng-repeat="check in answer_cumulative_checks"
           aria-checked="{{isCheckSelected(answer, check) ? 'true' : 'false'}}"
           ng-click="toggleSelectItemCumulative(question, answer, check)"
@@ -44,7 +45,7 @@
           tabindex="0"
           role="checkbox"
           aria-checked="{{isCheckSelected(answer, 0) ? 'true' : 'false'}}"
-          aria-labelledby="question_{{question.index}}_answer_{{answer.id}}"
+          aria-label="{{answer.text}} check invalid"
           ng-if="!!isInvalidVoteAnswer && question.tally_type === 'cumulative'"
           ng-click="toggleSelectItemCumulative(question, answer, 0)"
           ng-class="{

--- a/avBooth/simultaneous-question-answer-directive/simultaneous-question-answer-directive.less
+++ b/avBooth/simultaneous-question-answer-directive/simultaneous-question-answer-directive.less
@@ -89,6 +89,9 @@
         font-size: 18px;
         font-weight: bold;
         word-break: keep-all;
+        display: inline-block;
+        max-width: 100%;
+        margin-bottom: 5px;
       }
 
       .answer-details {

--- a/avBooth/simultaneous-questions-screen-directive/simultaneous-questions-screen-directive.html
+++ b/avBooth/simultaneous-questions-screen-directive/simultaneous-questions-screen-directive.html
@@ -123,7 +123,7 @@
         class="col-md-offset-2 col-md-8 text-warning input-error error-list"
         ng-class="{'col-xs-8': showSkipQuestionButton, 'col-xs-12': !showSkipQuestionButton}"
       >
-        <ul ng-if="errors.length > 0">
+        <ul ng-if="errors.length > 0" role="alert">
           <li
             class="error"
             ng-repeat="error in errors"

--- a/avBooth/success-screen-directive/success-screen-directive.html
+++ b/avBooth/success-screen-directive/success-screen-directive.html
@@ -30,12 +30,12 @@
 
           <div class="text-center" ng-if="hasNextElection">
             <span>
-              <a
+              <button
                 tabindex="0"
                 ng-click="goToNextElection()"
                 class="btn btn-primary btn-login" ng-i18next>
                 avBooth.goToNextElection
-              </a>
+              </button>
             </span>
           </div>
           <div 
@@ -43,13 +43,13 @@
             ng-if="!hasNextElection && (!election.presentation || !election.presentation.extra_options || !election.presentation.extra_options.success_screen__redirect_to_login)"
           >
             <span>
-              <a
+              <button
                 tabindex="0"
                 ng-click="closeAndFinish(false, true)"
 		            target="_top"
                 class="close-window-btn btn btn-primary btn-login" ng-i18next>
                 avBooth.closeWindow
-              </a>
+              </button>
             </span>
           </div>
 
@@ -66,7 +66,7 @@
           </span>
         </div>
         <div class="text-center download-ticket">
-          <a
+          <button
             class="btn btn-primary btn-login"
             tabindex="0"
             ng-click="downloadBallotTicket()"
@@ -74,7 +74,7 @@
             target="_blank"
             ng-i18next>
             avBooth.downloadBallotTicket
-          </a>
+          </button>
         </div>
         <p
           class="text-center"
@@ -90,12 +90,12 @@
         </p>
         <div class="text-center" ng-if="!hasNextElection && !!election.presentation.extra_options.success_screen__redirect_to_login">
           <span>
-            <a
+            <button
               tabindex="0"
               ng-click="redirectToLogin(true)"
               class="btn btn-primary btn-login">
               {{ election.presentation.extra_options.success_screen__redirect_to_login__text }}
-            </a>
+            </button>
           </span>
         </div>
         <div class="text-center" ng-if="!!election.presentation.share_text">

--- a/locales/en.json
+++ b/locales/en.json
@@ -21,6 +21,7 @@
   },
   "avCommon": {
     "cancel": "Cancel",
+    "changeLanguageMenu": "Change Language",
     "poweredBy": "Powered by <strong><a href=\"__url__\" target=\"_blank\">__name__</a></strong>",
     "shareLink": "¡Tweet this election!",
     "votingSystem": "Voting System",
@@ -53,6 +54,11 @@
         "title": "Choose an election to vote",
         "description": "Note: disabled elections mean you have already voted or you don't have permission to vote."
       }
+    },
+    "logoutWarnModal": {
+      "header": "Session will expire",
+      "body": "Your session is about to expire. In one minute you will be redirected if you haven't finished casting your vote.",
+      "confirm": "Close"
     },
     "demoModeModal": {
       "header": "Demo voting booth",
@@ -295,7 +301,8 @@
       "castTitle": "cast",
       "castDescription": "using a secure channel and verifying your identity",
       "anonymizedTitle": "anonymized",
-      "anonymizedDescription": "so that the tally does not reveal which way you voted"
+      "anonymizedDescription": "so that the tally does not reveal which way you voted",
+      "description": "Your ballot is being encrypted so that nobody can know what options you chose"
     },
 
     "tooFewAnswers": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -21,6 +21,7 @@
   },
   "avCommon": {
     "cancel": "Cancelar",
+    "changeLanguageMenu": "Cambiar idioma",
     "poweredBy": "Funciona con <strong><a href=\"__url__\" target=\"_blank\">__name__</a></strong>",
     "shareLink": "¡Twittea esta votación!",
     "votingSystem": "Sistema de Voto",
@@ -44,6 +45,11 @@
       "header": "Cabina de votación de demo",
       "body": "Está ingresando a una cabina de votación de demostración. <strong>Su voto NO se emitirá</strong>. Esta cabina de votación solo tiene fines demostrativos.",
       "confirm": "Acepto que mi voto NO se emitirá"
+    },
+    "logoutWarnModal": {
+      "header": "La sesión caducará",
+      "body": "Tu sesión va a caducar. En un minuto serás redirigido si no has terminado de emitir tu voto.",
+      "confirm": "Cerrar"
     },
     "previewModeModal": {
       "header": "Previsualización de cabina de votación",
@@ -264,7 +270,8 @@
       "castTitle": "emitido",
       "castDescription": "usando un canal seguro y verificando su identidad",
       "anonymizedTitle": "anonimizado",
-      "anonymizedDescription": "para que el recuento no revele el sentido de su voto"
+      "anonymizedDescription": "para que el recuento no revele el sentido de su voto",
+      "description": "Su voto está siendo cifrado para que nadie pueda saber qué opciones escogió"
     },
 
     "tooFewAnswers": {


### PR DESCRIPTION
# Changes
* Don't logout after 10 mins on demo/live.
* Show a warning modal before the session expires.
* Fix alt text for logo.
* Fix contrast for text warning javascript is off.
* Fix skipped headers on election chooser.
* Improve accessibility on encrypting screen, aria hide changing images, set better description for header.
* Set tabindex to 0 (instead of > 0) on modals' buttons.
* Don't use a header on review ballot when it just contains an aria-hidden icon.
* Add a description for the edit action on review ballot.
* Add alert role to warnings on simultaneous questions screen.
* Better labels for checks (normal, invalid, write-in) on simultaneous questions screen.
* Disable tab for answer container on simultaneous questions screen. Users should only be able to use tab to go through clickable/editable objects.
* Enable tab for buttons on success screen.
* Fix `links` on accordion options.
* Fix input labels  on conditional accordion, multi-question, pcandidates.