### PR TITLE
Add support for warn-invalid-implicit-and-explicit  (#298)

### DIFF
--- a/avBooth/simultaneous-questions-screen-directive/simultaneous-questions-screen-directive.js
+++ b/avBooth/simultaneous-questions-screen-directive/simultaneous-questions-screen-directive.js
@@ -143,6 +143,20 @@ angular.module('avBooth')
                   },
                   postfix: "-blank"
                 },
+                // raise if vote is explicitly invalid if not checkerTypeFlag
+                {
+                  check: "lambda",
+                  validator: function (question)
+                  {
+                    return !(
+                      checkerTypeFlag === "normal" &&
+                      question.extra_options.invalid_vote_policy === "warn-invalid-implicit-and-explicit" &&
+                      question.invalidVoteAnswer &&
+                      question.invalidVoteAnswer.selected > -1
+                    );
+                  },
+                  postfix: "-invalid"
+                },
                 // raise if numSelectedOptions < min, but not if blank, and
                 // checkerTypeFlag is normal and invalidVoteAnswer is not set
                 {

--- a/locales/en.json
+++ b/locales/en.json
@@ -83,6 +83,7 @@
       "cancel": "Cancel"
     },
     "errors": {
+      "question-lambda-invalid": "Question '__qtitle__': Invalid vote.",
       "question-lambda-blank": "Question '__qtitle__': selected zero options. Blank vote.",
       "question-lambda-min": "Question '__qtitle__': selected __num_selected__ options, less than the minimum __min__. Invalid vote.",
       "question-lambda-max": "Question '__qtitle__': selected __num_selected__ options, more than the maximum __max__. Invalid vote.",

--- a/locales/es.json
+++ b/locales/es.json
@@ -69,6 +69,7 @@
       "cancel": "Cancelar"
     },
     "errors": {
+      "question-lambda-invalid": "Votación '__qtitle__': Voto inválido.",
       "question-lambda-blank": "Votación '__qtitle__': seleccionó 0 candidaturas. Voto en blanco.",
       "question-lambda-min": "Votación '__qtitle__': seleccionó __num_selected__ candidaturas, menos que el mínimo de __min__. Voto inválido.",
       "question-lambda-max": "Votación '__qtitle__': seleccionó __num_selected__ candidaturas, más que el máximo de __max__. Voto inválido.",


### PR DESCRIPTION
* wip

* wip

* wip

* translations