### PR TITLE
Remove linear gradient

### DIFF
--- a/avBooth/booth-directive/booth-directive.less
+++ b/avBooth/booth-directive/booth-directive.less
@@ -132,7 +132,6 @@
     width: 100%;
     height: 30px;
     content: " ";
-    background: linear-gradient(to bottom, fade(@av-primary, 0%) 0%, @av-primary 100%);
   }
 
   #avb-toggle {


### PR DESCRIPTION
# Changes

* Remove`linear-gradient` background for class `wrapper-unfixed:after`, which was creating problems. This class is used in almost every screen in the voting booth.