### PR TITLE
Always fix continue button to bottom

### DIFF
--- a/avBooth/2questions-conditional-screen-directive/2questions-conditional-screen-directive.html
+++ b/avBooth/2questions-conditional-screen-directive/2questions-conditional-screen-directive.html
@@ -55,7 +55,13 @@
     </div>
 
     <!-- next button -->
-    <div class="row hidden" ng-cloak av-affix-bottom data-force-affix-width="768">
+    <div
+      class="row hidden"
+      ng-cloak
+      av-affix-bottom
+      data-force-affix-width="768"
+      data-force-affix="{{ election.presentation.anchor_continue_btn_to_bottom }}"
+    >
       <button
         class="btn btn-block btn-lg btn-success-action btn-plain"
         ng-i18next="avBooth.continueButton"

--- a/avBooth/audit-ballot-screen-directive/audit-ballot-screen-directive.html
+++ b/avBooth/audit-ballot-screen-directive/audit-ballot-screen-directive.html
@@ -12,7 +12,12 @@
         <div ng-i18next="[html:i18next]({ballotHash: stateData.ballotHash, auditableBallot: auditableBallotStr})avBooth.auditBallotText"></div>
       </div>
     </div>
-    <div class="row hidden" ng-cloak av-affix-bottom data-force-affix-width="768">
+    <div
+      class="row hidden"
+      ng-cloak
+      av-affix-bottom data-force-affix-width="768"
+      data-force-affix="{{ election.presentation.anchor_continue_btn_to_bottom }}"
+    >
 
       <div class="col-xs-12 no-padding">
         <button

--- a/avBooth/conditional-accordion-screen-directive/conditional-accordion-screen-directive.html
+++ b/avBooth/conditional-accordion-screen-directive/conditional-accordion-screen-directive.html
@@ -95,7 +95,13 @@
     </div>
 
     <!-- next button -->
-    <div class="row hidden" ng-cloak av-affix-bottom="stateData.affixIsSet" data-force-affix-width="768">
+    <div
+      class="row hidden"
+      ng-cloak
+      av-affix-bottom="stateData.affixIsSet"
+      data-force-affix-width="768"
+      data-force-affix="{{ election.presentation.anchor_continue_btn_to_bottom }}"
+    >
       <p class="warnings">
         <span
           class="text-brand-warning"

--- a/avBooth/help-screen-directive/help-screen-directive.html
+++ b/avBooth/help-screen-directive/help-screen-directive.html
@@ -22,7 +22,13 @@
     </div>
 
     <!-- go back button -->
-    <div class="row hidden" ng-cloak av-affix-bottom data-force-affix-width="768">
+    <div
+      class="row hidden"
+      ng-cloak
+      av-affix-bottom
+      data-force-affix-width="768"
+      data-force-affix="{{ election.presentation.anchor_continue_btn_to_bottom }}"
+    >
       <button
         class="btn btn-block btn-lg btn-success-action btn-plain"
         ng-i18next="avBooth.goBack"

--- a/avBooth/pairwise-beta-directive/pairwise-beta-directive.html
+++ b/avBooth/pairwise-beta-directive/pairwise-beta-directive.html
@@ -165,7 +165,9 @@
       class="row hidden"
       ng-cloak
       av-affix-bottom="stateData.affixIsSet"
-      data-force-affix-width="768">
+      data-force-affix-width="768"
+      data-force-affix="{{ election.presentation.anchor_continue_btn_to_bottom }}"
+    >
       <button
         class="btn btn-block btn-lg btn-success-action btn-plain hidden"
         ng-i18next="avBooth.continueButton"

--- a/avBooth/review-screen-directive/review-screen-directive.html
+++ b/avBooth/review-screen-directive/review-screen-directive.html
@@ -22,7 +22,13 @@
         <div avb-review-ballot></div>
       </div>
     </div>
-    <div class="row hidden" ng-cloak av-affix-bottom data-force-affix-width="768">
+    <div
+      class="row hidden"
+      ng-cloak
+      av-affix-bottom
+      data-force-affix-width="768"
+      data-force-affix="{{ election.presentation.anchor_continue_btn_to_bottom }}"
+    >
       <div
         ng-if="!election.presentation.extra_options || !election.presentation.extra_options.disable_voting_booth_audit_ballot"
         class="col-xs-12 locator-text-click-audit">

--- a/avBooth/show-pdf-directive/show-pdf-directive.html
+++ b/avBooth/show-pdf-directive/show-pdf-directive.html
@@ -50,7 +50,14 @@
           ng-click="next()">
         </button>
       </div>
-      <div class="row hidden" ng-cloak av-affix-bottom data-force-affix-width="768" ng-if="expanded">
+      <div
+        class="row hidden"
+        ng-cloak
+        av-affix-bottom
+        data-force-affix-width="768"
+        ng-if="expanded"
+        data-force-affix="{{ election.presentation.anchor_continue_btn_to_bottom }}"
+      >
         <button
           class="btn btn-block btn-lg btn-success-action btn-plain"
           ng-i18next="avBooth.startVoting"

--- a/avBooth/simultaneous-questions-screen-directive/simultaneous-questions-screen-directive.html
+++ b/avBooth/simultaneous-questions-screen-directive/simultaneous-questions-screen-directive.html
@@ -119,6 +119,7 @@
       class="row hidden" 
       ng-cloak
       av-affix-bottom data-force-affix-width="768"
+      data-force-affix="{{ election.presentation.anchor_continue_btn_to_bottom }}"
     >
 
       <div

--- a/avBooth/start-screen-directive/start-screen-directive.html
+++ b/avBooth/start-screen-directive/start-screen-directive.html
@@ -58,7 +58,11 @@
       </div>
 
     </div>
-    <div class="row hidden" ng-cloak av-affix-bottom data-force-affix-width="768">
+    <div class="row hidden" ng-cloak
+      av-affix-bottom
+      data-force-affix-width="768"
+      data-force-affix="{{ election.presentation.anchor_continue_btn_to_bottom }}"
+    >
       <button
         class="btn btn-block btn-lg btn-success-action btn-plain"
         ng-i18next="avBooth.startVoting"


### PR DESCRIPTION
# Changes

* In all screens using the affix bottom directive, force it to be active if the election config `election.presentation.anchor_continue_btn_to_bottom`is set to true. 