### PR TITLE
Fix ORT Github Workflow (#317)

### DIFF
--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -18,9 +18,6 @@ on:
 
 jobs:
   ort:
-    uses: sequentech/ort-config/.github/workflows/ort.yml@main
+    uses: sequentech/meta/.github/workflows/ort.yml@main
     with:
-      ort-cli-args: > # using the default plus the package managers setting
-        --force-overwrite
-        --stacktrace
-        -P ort.analyzer.enabledPackageManagers=Yarn
+      ort-cli-analyze-args: '--package-managers Yarn'


### PR DESCRIPTION
Use the reusable workflow from the meta repository instead.