### PR TITLE
Voting Booth: show ballot warnings in review screen (#322)

### DIFF
--- a/avBooth/review-screen-directive/review-screen-directive.html
+++ b/avBooth/review-screen-directive/review-screen-directive.html
@@ -29,6 +29,17 @@
       data-force-affix-width="768"
       data-force-affix="{{ election.presentation.anchor_continue_btn_to_bottom }}"
     >
+      <div ng-if="election.errors && election.errors.length > 0" class="text-warning input-error error-list col-xs-12">
+        <ul role="alert">
+          <li
+            class="error"
+            ng-repeat="error in election.errors"
+            data-i18n="{{error.data}}"
+            ng-i18next>
+            [html:i18next]({{error.data}}){{error.key}}
+          </li>
+        </ul>
+      </div>
       <div
         ng-if="!election.presentation.extra_options || !election.presentation.extra_options.disable_voting_booth_audit_ballot"
         class="col-xs-12 locator-text-click-audit">

--- a/avBooth/review-screen-directive/review-screen-directive.less
+++ b/avBooth/review-screen-directive/review-screen-directive.less
@@ -24,12 +24,17 @@
     padding: 0;
   }
 
+  .error-list li {
+    word-break: keep-all;
+  }
+
   .election-title {
     word-break: keep-all;
   }
 
   .locator-text-click-audit {
-    margin: 20px 0 10px 0;
+    margin: 0;
+    text-align: center;
 
     .review-ballot-hash-text, .review-ballot-link {
       overflow-wrap: anywhere;
@@ -40,6 +45,17 @@
 
     .review-ballot-link {
       padding-left: 5px;
+    }
+  }
+
+  [av-affix-bottom] {
+    max-height: 150px;
+
+    .error-list {
+      display: flex;
+      justify-content: center;
+      align-items: flex-end;
+      text-align: center;
     }
   }
 
@@ -61,5 +77,12 @@
 
   .content a {
     font-weight: bold;
+  }
+}
+
+@media(max-width: @screen-sm-min) {
+  [avb-review-screen] [av-affix-bottom] .error-list > ul {
+    overflow-y: scroll;
+    max-height: 60px;
   }
 }

--- a/avBooth/simultaneous-questions-screen-directive/simultaneous-questions-screen-directive.js
+++ b/avBooth/simultaneous-questions-screen-directive/simultaneous-questions-screen-directive.js
@@ -458,6 +458,7 @@ angular.module('avBooth')
               });
             }
           });
+          scope.election.errors = angular.copy(scope.errors);
           
         }
         scope.updateErrors = updateErrors;


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/epi/issues/111

### Suggestion

When a ballot is invalid implicitly (for example by selecting too many choices by the voter), the voting screen shows a warning to the voter telling him that this will make the ballot invalid However, in the review screen no warning is shown. The proposal is to show this warning in the review screen too.

### Implementation details and rationale

Note that this feature is already implemented for the [new voting booth design](https://github.com/sequentech/voting-booth/issues/304) that will be launched in a couple weeks in version `8.0.0`, but EPI wants to have access to this feature in version `7.x` to be able to deploy the breaking changes of version `8.0.0` later with more time and internal testing.

After a debate seen below, we implemented this feature by saving the warnings from the ballot selection screen and show them in a similar manner in the review screen. We will not only show the implicit invalid vote warning, but more generally the same warnings shown in the ballot selection screen for consistency.

The change in the review screen can be seen in the screenshot below:

![Image](https://user-images.githubusercontent.com/81968/236503608-708d9515-a691-4298-91c7-485e5770c248.png)

As it can be seen and for visual consistency with respect to the warnings shown on top of it, we center-aligned the ballot tracker line on top of the action button in review screen. The warnings are shown in the bottom section of the screen, that in certain cases (for example if it's [configured to be anchored to the
bottom](https://sequentech.github.io/documentation/docs/general/reference/election-creation-json#election-presentation-anchor_continue_btn_to_bottom) or if it's a small screen device) it's part of the anchored and sticky part of the window, being always shown. That works just like in the ballot selection screen.

### Tasks

```[tasklist]
# Tasks
- [x] Implement saving the warning from the ballot selection screen and show them in a similar manner in the review screen
```