### PR TITLE
Fix: Responsive wraps for high cumulative votes

### DIFF
--- a/avBooth/simultaneous-question-answer-v2-directive/simultaneous-question-answer-v2-directive.less
+++ b/avBooth/simultaneous-question-answer-v2-directive/simultaneous-question-answer-v2-directive.less
@@ -63,7 +63,7 @@
     }
 
     .cumulative-checkbox {
-      margin-left: 12px;
+      margin: 6px;
     }
 
     .answer-texts {
@@ -169,6 +169,7 @@
   
   .vertilize-col.answer-glyphicon {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     padding: 28px 6px 28px 14px;
 


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/211

Problem solved: checkboxes overflow to the side instead of wrapping in a new rows.