### PR TITLE
Fix: Responsive wraps for high cumulative votes (#371)

### DIFF
--- a/avBooth/simultaneous-question-answer-v2-directive/simultaneous-question-answer-v2-directive.html
+++ b/avBooth/simultaneous-question-answer-v2-directive/simultaneous-question-answer-v2-directive.html
@@ -143,6 +143,8 @@
       <div class="vertilize-col answer-glyphicon" ng-if="!hideCheck()">
         <span
           tabindex="0"
+          class="plurality-checkbox"
+          role="checkbox"
           aria-labelledby="question_{{question.index}}_answer_{{answer.id}}"
           ng-if="question.tally_type === 'plurality-at-large'"
           ng-click="$event.stopPropagation(); !readOnly() && toggleSelectItem(question, answer)"
@@ -167,6 +169,7 @@
         <!-- show checkbox for invalid -->
         <span
           tabindex="0"
+          class="invalid-checkbox"
           role="checkbox"
           aria-checked="{{isCheckSelected(answer, 0) ? 'true' : 'false'}}"
           aria-label="{{answer | customI18n : 'text'}} check invalid"

--- a/avBooth/simultaneous-question-answer-v2-directive/simultaneous-question-answer-v2-directive.less
+++ b/avBooth/simultaneous-question-answer-v2-directive/simultaneous-question-answer-v2-directive.less
@@ -114,14 +114,14 @@
       cursor: unset;
     }
 
-    .cumulative-checkbox {
+    .cumulative-checkbox, .plurality-checkbox, .invalid-checkbox {
       margin: 6px;
     }
 
     .answer-texts {
       box-sizing: border-box;
       padding-right: 10px;
-      width: 100%;
+      flex-basis: 100%;
       margin: auto 0;
 
       &.write-in {
@@ -221,9 +221,12 @@
   
   .vertilize-col.answer-glyphicon {
     display: flex;
+    flex-basis: 100%;
+    max-width: 26%;
+    justify-content: flex-end;
     flex-wrap: wrap;
     align-items: center;
-    padding: 28px 6px 28px 14px;
+    padding: 6x 6px 6px 0;
 
     .fa-check {
       background-color: @brand-success;


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/211

Problem solved: checkboxes overflow to the side instead of wrapping in a new rows. Previous fix was incomplete.